### PR TITLE
feat: retro phase UX fixes + anonymous typing indicator

### DIFF
--- a/party/retro.ts
+++ b/party/retro.ts
@@ -14,8 +14,10 @@ import {
  * transition(), broadcasts new state. Server is single source of truth.
  *
  * ANONYMITY: During writing phase, the server strips the sender's
- * real identity and assigns a random anonymousId. The mapping is
- * NEVER broadcast. No typing indicators are sent.
+ * real identity and assigns a random anonymousId. The mapping is NEVER
+ * broadcast. Typing indicators are ephemeral: only participantIds are
+ * broadcast (never names), and clients filter their own ID before showing
+ * the indicator. Typing state is never persisted to storage.
  */
 
 interface ConnectionState {
@@ -32,6 +34,8 @@ function generateId(): string {
 export default class RetroServer implements Party.Server {
   state: RetroState;
   timerInterval: ReturnType<typeof setInterval> | null = null;
+  /** Ephemeral set of participantIds currently typing. Never persisted. */
+  private typingParticipants: Set<string> = new Set();
 
   constructor(readonly room: Party.Room) {
     this.state = createInitialState("");
@@ -138,6 +142,18 @@ export default class RetroServer implements Party.Server {
       return;
     }
 
+    // ── Typing indicators (ephemeral, never persisted, never includes names) ──
+    if (parsed.type === "TYPING_START") {
+      this.typingParticipants.add(connState.participantId);
+      this.broadcastTyping();
+      return;
+    }
+    if (parsed.type === "TYPING_STOP") {
+      this.typingParticipants.delete(connState.participantId);
+      this.broadcastTyping();
+      return;
+    }
+
     let event = parsed as RetroEvent;
 
     // ── Anonymity enforcement for ADD_CARD ──
@@ -211,17 +227,32 @@ export default class RetroServer implements Party.Server {
   async onClose(conn: Party.Connection) {
     const connState = conn.state as ConnectionState | undefined;
     if (connState) {
+      // Remove from typing set and broadcast if they were typing when they disconnected
+      if (this.typingParticipants.has(connState.participantId)) {
+        this.typingParticipants.delete(connState.participantId);
+        this.broadcastTyping();
+      }
+
       this.state = transition(this.state, {
         type: "PARTICIPANT_LEAVE",
         participantId: connState.participantId,
       });
 
-      // Reassign facilitator if needed
+      // Fix 6: if the leaving participant is the room creator, keep facilitatorId
+      // as-is and wait for the creator to reconnect (reclaim-on-join handles return).
+      // Only reassign if the leaver is a non-creator facilitator.
       if (this.state.facilitatorId === connState.participantId) {
-        const next = this.getFirstConnectedParticipantId(connState.participantId);
-        if (next) {
-          this.state = { ...this.state, facilitatorId: next };
+        const isCreator =
+          connState.userId !== null && connState.userId === this.state.createdBy;
+        if (!isCreator) {
+          const next = this.getFirstConnectedParticipantId(connState.participantId);
+          if (next) {
+            this.state = { ...this.state, facilitatorId: next };
+          }
         }
+        // If the creator is leaving, facilitatorId intentionally keeps pointing to their
+        // (now disconnected) participantId. The reclaim-on-join logic in onConnect will
+        // restore it when they reconnect.
       }
 
       await this.persist();
@@ -329,6 +360,15 @@ export default class RetroServer implements Party.Server {
 
   private broadcast() {
     const message = JSON.stringify({ type: "update", state: this.state });
+    this.room.broadcast(message);
+  }
+
+  /** Broadcast the current typing set to all connections. Never includes names. */
+  private broadcastTyping() {
+    const message = JSON.stringify({
+      type: "typing_update",
+      participantIds: Array.from(this.typingParticipants),
+    });
     this.room.broadcast(message);
   }
 

--- a/src/app/(app)/retro/[id]/page.tsx
+++ b/src/app/(app)/retro/[id]/page.tsx
@@ -161,6 +161,9 @@ function RetroRoom({
     removeActionItem,
     updateActionItem,
     closeRetro,
+    typingOthers,
+    startTyping,
+    stopTyping,
   } = useRetroRoom({ roomId, playerName, clerkUserId });
 
   // Unresolved items from previous retro (groups without action items)
@@ -292,6 +295,9 @@ function RetroRoom({
             isFacilitator={isFacilitator}
             onAdvance={advancePhase}
             participantCount={state.participants.length}
+            typingOthers={typingOthers}
+            onStartTyping={startTyping}
+            onStopTyping={stopTyping}
           />
         )}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -393,6 +393,24 @@
   animation: timer-pulse 2s var(--ease-ceremony) infinite;
 }
 
+/* ── Typing indicator dot ── */
+
+@keyframes typing-pulse {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+.typing-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: currentColor;
+  animation: typing-pulse 1.2s ease-in-out infinite;
+  color: var(--muted-foreground);
+  opacity: 0.7;
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -422,6 +440,10 @@
   }
   .timer-pulse {
     animation: none;
+  }
+  .typing-dot {
+    animation: none;
+    opacity: 0.5;
   }
   [class*="animate-[drift"] {
     animation: none !important;

--- a/src/components/retro/discuss-act-phase.tsx
+++ b/src/components/retro/discuss-act-phase.tsx
@@ -157,11 +157,11 @@ function TopicSection({
     >
       {/* Topic header */}
       <div className="flex items-center justify-between border-b-2 border-border bg-muted/30 px-5 py-3">
-        <div className="flex items-center gap-3">
-          <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
             {rank}
           </span>
-          <h3 className="font-display text-lg tracking-ceremony">
+          <h3 className="min-w-0 break-words font-display text-lg tracking-ceremony">
             {group.label}
           </h3>
         </div>

--- a/src/components/retro/grouping-phase.tsx
+++ b/src/components/retro/grouping-phase.tsx
@@ -280,16 +280,70 @@ export function GroupingPhase({
             {groups.length} group{groups.length !== 1 ? "s" : ""} formed:
           </span>
           {groups.map((g) => (
-            <span
+            <RenameableChip
               key={g.id}
-              className="rounded-md border-2 border-border bg-muted px-2.5 py-1 text-xs font-bold"
-            >
-              {g.label} ({g.cardIds.length})
-            </span>
+              group={g}
+              onRename={onRenameGroup}
+            />
           ))}
         </div>
       )}
     </div>
+  );
+}
+
+/** Inline-editable chip for renaming a group from the summary row. */
+function RenameableChip({
+  group,
+  onRename,
+}: {
+  group: CardGroup;
+  onRename: (groupId: string, label: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [label, setLabel] = useState(group.label);
+
+  // Sync when an external rename (e.g. canvas boundary) changes the label.
+  useEffect(() => {
+    if (!editing) setLabel(group.label);
+  }, [group.label, editing]);
+
+  const handleSave = () => {
+    const trimmed = label.trim();
+    if (trimmed && trimmed !== group.label) {
+      onRename(group.id, trimmed);
+    } else {
+      setLabel(group.label);
+    }
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        onBlur={handleSave}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSave();
+          if (e.key === "Escape") { setLabel(group.label); setEditing(false); }
+        }}
+        autoFocus
+        className="h-7 rounded-md border-2 border-primary bg-card px-2 text-xs font-bold focus:outline-none"
+        style={{ minWidth: "6rem" }}
+      />
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setEditing(true)}
+      className="flex items-center gap-1 rounded-md border-2 border-border bg-muted px-2.5 py-1 text-xs font-bold transition-colors hover:border-primary hover:bg-primary/10"
+      title="Click to rename group"
+    >
+      {group.label} ({group.cardIds.length})
+      <EditPencil width={10} height={10} className="shrink-0 text-muted-foreground" />
+    </button>
   );
 }
 

--- a/src/components/retro/grouping-phase.tsx
+++ b/src/components/retro/grouping-phase.tsx
@@ -238,7 +238,7 @@ export function GroupingPhase({
               onPointerDown={(e) => handlePointerDown(card.id, e)}
             >
               <Icon size={20} className={cn("shrink-0 mt-0.5", style.color)} />
-              <span className="line-clamp-4 leading-snug">{card.text}</span>
+              <span className="leading-snug">{card.text}</span>
             </div>
           );
         })}

--- a/src/components/retro/voting-phase.tsx
+++ b/src/components/retro/voting-phase.tsx
@@ -148,6 +148,15 @@ export function VotingPhase({
             Results revealed! Groups are now sorted by votes.
           </p>
         )}
+
+        {/* Facilitator advance button lives here so it is visible without scrolling */}
+        {isFacilitator && allVotesIn && (
+          <div className="mt-3 flex justify-center consensus-enter">
+            <Button onClick={onAdvance} className="h-11">
+              Start discussion
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Groups to vote on */}
@@ -260,15 +269,6 @@ export function VotingPhase({
           );
         })}
       </div>
-
-      {/* Facilitator advance: only after all votes are revealed */}
-      {isFacilitator && allVotesIn && (
-        <div className="text-center pt-2 consensus-enter">
-          <Button onClick={onAdvance} className="h-11">
-            Start discussion
-          </Button>
-        </div>
-      )}
 
       {isFacilitator && !allVotesIn && (
         <div className="space-y-1.5 text-center pt-2">

--- a/src/components/retro/writing-phase.tsx
+++ b/src/components/retro/writing-phase.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { RetroCard, CardCategory } from "@/lib/state-machines/retro";
 import { Button } from "@/components/ui/button";
 import { HappyIcon, SadIcon, ConfusedIcon } from "@/components/shared/icons";
@@ -16,6 +16,10 @@ interface WritingPhaseProps {
   readonly isFacilitator: boolean;
   readonly onAdvance: () => void;
   readonly participantCount: number;
+  /** How many other participants are currently typing (excludes self). */
+  readonly typingOthers: number;
+  readonly onStartTyping: () => void;
+  readonly onStopTyping: () => void;
 }
 
 const CATEGORIES: ReadonlyArray<{
@@ -61,15 +65,41 @@ export function WritingPhase({
   isFacilitator,
   onAdvance,
   participantCount,
+  typingOthers,
+  onStartTyping,
+  onStopTyping,
 }: WritingPhaseProps) {
   const [activeCategory, setActiveCategory] = useState<CardCategory>("happy");
   const [text, setText] = useState("");
   const [editingCardId, setEditingCardId] = useState<string | null>(null);
   const [editText, setEditText] = useState("");
 
+  // Debounce ref for the typing stop timeout.
+  const stopTypingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up the typing indicator when the component unmounts (e.g. phase changes).
+  useEffect(() => {
+    return () => {
+      if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+      onStopTyping();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleTextChange = (value: string) => {
+    setText(value);
+    onStartTyping();
+    if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+    stopTypingTimer.current = setTimeout(() => {
+      onStopTyping();
+    }, 3000);
+  };
+
   const handleSubmit = () => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+    onStopTyping();
     onAddCard(activeCategory, trimmed);
     setText("");
   };
@@ -120,7 +150,7 @@ export function WritingPhase({
       <div className="space-y-3">
         <textarea
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => handleTextChange(e.target.value)}
           placeholder={`What made you ${activeCategory}?`}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
@@ -135,7 +165,19 @@ export function WritingPhase({
             `focus:${activeCat.borderClass}`
           )}
         />
-        <div className="flex justify-end">
+
+        {/* Anonymous typing indicator: shows when others are typing. Never shows names. */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 h-4">
+            {typingOthers > 0 && (
+              <>
+                <span className="typing-dot" />
+                <span className="text-[11px] font-medium text-muted-foreground opacity-70">
+                  Someone is typing...
+                </span>
+              </>
+            )}
+          </div>
           <Button
             onClick={handleSubmit}
             disabled={!text.trim()}

--- a/src/hooks/use-retro-room.ts
+++ b/src/hooks/use-retro-room.ts
@@ -25,6 +25,13 @@ interface UseRetroRoomResult {
   readonly isFacilitator: boolean;
   readonly connected: boolean;
 
+  /** Number of other participants currently typing (excludes self). */
+  readonly typingOthers: number;
+  /** Notify the server that this participant started typing. */
+  readonly startTyping: () => void;
+  /** Notify the server that this participant stopped typing. */
+  readonly stopTyping: () => void;
+
   // Lobby
   readonly startRetro: (options?: { teamId?: string; createdBy?: string; previousActions?: ReadonlyArray<PreviousAction> }) => void;
 
@@ -82,6 +89,7 @@ export function useRetroRoom({
   const [myAnonymousId, setMyAnonymousId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [cursors, setCursors] = useState<ReadonlyMap<string, CursorPosition>>(new Map());
+  const [typingParticipantIds, setTypingParticipantIds] = useState<ReadonlyArray<string>>([]);
   const stateRef = useRef(state);
 
   useEffect(() => {
@@ -136,6 +144,8 @@ export function useRetroRoom({
           });
           return next;
         });
+      } else if (data.type === "typing_update") {
+        setTypingParticipantIds(data.participantIds as string[]);
       }
     },
   });
@@ -199,6 +209,14 @@ export function useRetroRoom({
     },
     [send, myAnonymousId]
   );
+
+  const startTyping = useCallback(() => {
+    send({ type: "TYPING_START" });
+  }, [send]);
+
+  const stopTyping = useCallback(() => {
+    send({ type: "TYPING_STOP" });
+  }, [send]);
 
   // ── Grouping (canvas) ──
 
@@ -334,12 +352,18 @@ export function useRetroRoom({
 
   const isFacilitator = Boolean(myId && state && state.facilitatorId === myId);
 
+  // Count participants typing, excluding self. Never includes names.
+  const typingOthers = typingParticipantIds.filter((id) => id !== myId).length;
+
   return {
     state,
     myId,
     myAnonymousId,
     isFacilitator,
     connected,
+    typingOthers,
+    startTyping,
+    stopTyping,
     startRetro,
     markAction,
     advancePhase,

--- a/src/lib/state-machines/retro.ts
+++ b/src/lib/state-machines/retro.ts
@@ -284,7 +284,7 @@ export function transition(state: RetroState, event: RetroEvent): RetroState {
         const ungrouped = state.cards.filter((c) => !groupedCardIds.has(c.id));
         const newGroups = ungrouped.map((c) => ({
           id: `auto-${c.id}`,
-          label: c.text.slice(0, 40),
+          label: c.text,
           cardIds: [c.id] as ReadonlyArray<string>,
           voteCount: 0,
         }));
@@ -647,9 +647,7 @@ export function computeProximityGroups(
   const groups: CardGroup[] = [];
   for (const [root, members] of clusters) {
     const firstCard = cards.find((c) => c.id === members[0]);
-    const label = firstCard
-      ? firstCard.text.slice(0, 30) + (firstCard.text.length > 30 ? "..." : "")
-      : "Group";
+    const label = firstCard ? firstCard.text : "Group";
     groups.push({
       id: `prox-${root}`,
       label,

--- a/tests/retro-facilitator-promotion.mjs
+++ b/tests/retro-facilitator-promotion.mjs
@@ -8,8 +8,10 @@
  *   1. Anonymous participant A joins first and becomes facilitator (fallback).
  *   2. Creator participant B joins with userId matching state.createdBy.
  *      Facilitator should transfer to B.
- *   3. B disconnects. Facilitator should fall back to A.
- *   4. B reconnects. Facilitator should transfer back to B (creator reclaims).
+ *   3. B (creator) disconnects. Facilitator should STAY as B's participantId,
+ *      NOT fall back to A. The role is sticky to the creator.
+ *   4. B reconnects. Facilitator should transfer to B2's new participantId
+ *      (creator reclaims on join, no double-assignment).
  *
  * Usage: node tests/retro-facilitator-promotion.mjs [host] [roomId]
  *
@@ -149,26 +151,35 @@ async function run() {
     "A's broadcast state also shows B as facilitator"
   );
 
-  // ── Step 3: B disconnects, facilitator falls back to A ──
-  log("Disconnecting B...");
+  // ── Step 3: B (creator) disconnects. Facilitator role is sticky to the creator. ──
+  // The facilitatorId should STAY pointing to B's (now-disconnected) participantId.
+  // It must NOT fall back to A. Reclaim-on-join will restore it when B reconnects.
+  log("Disconnecting B (creator)...");
+  const bParticipantId = b.id; // capture before close
   await close(b);
   await sleep(500); // let onClose propagate and broadcast
 
   assert(
-    a.getState().facilitatorId === a.id,
-    "After B disconnects, facilitator falls back to A"
+    a.getState().facilitatorId === bParticipantId,
+    "After B (creator) disconnects, facilitatorId stays as B's participantId (not reassigned to A)"
+  );
+  assert(
+    a.getState().facilitatorId !== a.id,
+    "facilitatorId is NOT A's id after B (creator) disconnects"
   );
 
-  // ── Step 4: B reconnects, reclaims facilitator ──
+  // ── Step 4: B reconnects. Reclaims facilitator via reclaim-on-join. ──
   log("Reconnecting B (creator)...");
   const b2 = await connect("Bob (Creator)", CREATOR_USER_ID);
   log(`  B2 joined, id=${b2.id}`);
 
+  // B2 gets a new participantId on reconnect. The reclaim-on-join logic in onConnect
+  // should promote B2 to facilitator because their userId matches state.createdBy.
   await waitForFacilitator(a.getState, b2.id);
 
   assert(
     b2.getState().facilitatorId === b2.id,
-    "B (creator) reclaims facilitator on reconnect"
+    "B (creator) reclaims facilitator on reconnect (no double-assignment)"
   );
   assert(
     a.getState().facilitatorId === b2.id,

--- a/tests/retro-group-labels.mjs
+++ b/tests/retro-group-labels.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for auto-generated group labels.
+ *
+ * Verifies that:
+ *   1. Cards with long text (>30 chars, >40 chars) produce group labels that
+ *      equal the full card text, not a truncated version.
+ *   2. The "advance to voting" auto-group path uses the full card text.
+ *   3. The proximity-grouping path uses the full card text.
+ *
+ * These tests operate against a running PartyKit server by sending events and
+ * asserting on the returned state — consistent with the project's test pattern.
+ *
+ * Usage: node tests/retro-group-labels.mjs [host] [roomId]
+ *
+ * Requires a running PartyKit dev server and the "ws" npm package.
+ */
+
+import WebSocket from "ws";
+
+const HOST = process.argv[2] || "127.0.0.1:1999";
+const ROOM_ID = process.argv[3] || `label-test-${Date.now().toString(36)}`;
+
+const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+function assert(condition, msg) {
+  if (condition) {
+    log(`PASS: ${msg}`);
+  } else {
+    log(`FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+function connect(name, userId = null) {
+  return new Promise((resolve, reject) => {
+    const qs = new URLSearchParams({ name });
+    if (userId) qs.set("userId", userId);
+    const url = `ws://${HOST}/parties/retro/${ROOM_ID}?${qs.toString()}`;
+    const ws = new WebSocket(url);
+    let resolved = false;
+    let latestState = null;
+
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) {
+          resolved = true;
+          resolve({ ws, id: data.you, anonymousId: data.anonymousId, getState: () => latestState });
+        }
+      } else if (data.type === "update") {
+        latestState = data.state;
+      }
+    });
+
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error(`Timeout for "${name}"`)); }, 5000);
+  });
+}
+
+function waitFor(getState, predicate, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      const state = getState();
+      if (state && predicate(state)) return resolve(state);
+      if (Date.now() > deadline) return reject(new Error("waitFor timeout"));
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+async function run() {
+  log(`Room: ${ROOM_ID}`);
+
+  const fac = await connect("Facilitator");
+  log(`Facilitator joined, id=${fac.id}`);
+
+  // Start the retro (no previous actions, goes straight to writing)
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
+  log("Phase: writing");
+
+  // ── Scenario 1: auto-group label on advance-to-voting ──
+  // The old code truncated the label at 40 chars for this path.
+  const longText40 = "this is a fairly long topic name that exceeds forty characters easily yes it does";
+  assert(longText40.length > 40, "test text exceeds old 40-char threshold");
+
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText40 }));
+  await waitFor(fac.getState, (s) => s.cards.length > 0);
+
+  // Advance to grouping, then to voting (voting auto-groups ungrouped cards)
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
+  log("Phase: grouping");
+
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "voting");
+  log("Phase: voting");
+
+  const state = fac.getState();
+  assert(state.groups.length > 0, "at least one group exists after advance-to-voting");
+  const autoGroup = state.groups.find((g) => g.cardIds.length > 0);
+  assert(autoGroup !== undefined, "an auto-group was created");
+  assert(
+    autoGroup?.label === longText40,
+    `auto-group label equals full text (got "${autoGroup?.label?.slice(0, 50)}...")`
+  );
+
+  // ── Scenario 2: proximity-group label in grouping phase ──
+  // Use a separate room to test proximity grouping label via a fresh retro.
+  const ROOM_2 = `${ROOM_ID}-prox`;
+  const fac2 = await connect("Facilitator2");
+  // Connect to second room separately
+  const qs2 = new URLSearchParams({ name: "Fac2" });
+  const url2 = `ws://${HOST}/parties/retro/${ROOM_2}?${qs2.toString()}`;
+  const fac2b = await new Promise((resolve, reject) => {
+    const ws = new WebSocket(url2);
+    let latestState = null;
+    let resolved = false;
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) { resolved = true; resolve({ ws, id: data.you, getState: () => latestState }); }
+      } else if (data.type === "update") { latestState = data.state; }
+    });
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error("timeout")); }, 5000);
+  });
+
+  fac2b.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac2b.id }));
+  await waitFor(fac2b.getState, (s) => s.phase === "writing");
+
+  const longText30 = "this topic text is longer than thirty characters absolutely";
+  assert(longText30.length > 30, "test text exceeds old 30-char proximity threshold");
+
+  fac2b.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText30 }));
+  await waitFor(fac2b.getState, (s) => s.cards.length > 0);
+
+  // Advance to grouping
+  fac2b.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac2b.id }));
+  await waitFor(fac2b.getState, (s) => s.phase === "grouping");
+
+  // Move a card to trigger proximity grouping computation
+  const cardId = fac2b.getState().cards[0].id;
+  fac2b.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
+  await sleep(300);
+
+  const state2 = fac2b.getState();
+  const proxGroup = state2.groups.find((g) => g.cardIds.includes(cardId));
+  assert(proxGroup !== undefined, "proximity group contains the moved card");
+  assert(
+    proxGroup?.label === longText30,
+    `proximity group label equals full text (got "${proxGroup?.label?.slice(0, 50)}...")`
+  );
+
+  // ── Summary ──
+  log("=".repeat(50));
+  log("GROUP LABEL TESTS COMPLETE");
+  log("=".repeat(50));
+  if (failures === 0) {
+    log("ALL CHECKS PASSED");
+  } else {
+    log(`${failures} CHECK(S) FAILED`);
+  }
+
+  try { fac.ws.close(); } catch {}
+  try { fac2.ws.close(); } catch {}
+  try { fac2b.ws.close(); } catch {}
+
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/tests/retro-group-labels.mjs
+++ b/tests/retro-group-labels.mjs
@@ -1,14 +1,11 @@
 /**
- * Unit tests for auto-generated group labels.
+ * Group label and chip-rename tests.
  *
- * Verifies that:
- *   1. Cards with long text (>30 chars, >40 chars) produce group labels that
- *      equal the full card text, not a truncated version.
- *   2. The "advance to voting" auto-group path uses the full card text.
- *   3. The proximity-grouping path uses the full card text.
- *
- * These tests operate against a running PartyKit server by sending events and
- * asserting on the returned state — consistent with the project's test pattern.
+ * Three scenarios:
+ *   1. Advance-to-voting auto-group label uses the full card text (was truncated at 40 chars).
+ *   2. Proximity-group label uses the full card text (was truncated at 30 chars).
+ *   3. Renaming a group via RENAME_GROUP (what the summary chip calls) persists the new label
+ *      in state, and survives a card move that re-triggers proximity computation.
  *
  * Usage: node tests/retro-group-labels.mjs [host] [roomId]
  *
@@ -18,7 +15,7 @@
 import WebSocket from "ws";
 
 const HOST = process.argv[2] || "127.0.0.1:1999";
-const ROOM_ID = process.argv[3] || `label-test-${Date.now().toString(36)}`;
+const BASE_ROOM = process.argv[3] || `labels-${Date.now().toString(36)}`;
 
 const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -33,11 +30,11 @@ function assert(condition, msg) {
   }
 }
 
-function connect(name, userId = null) {
+function connectRoom(name, roomId, userId = null) {
   return new Promise((resolve, reject) => {
     const qs = new URLSearchParams({ name });
     if (userId) qs.set("userId", userId);
-    const url = `ws://${HOST}/parties/retro/${ROOM_ID}?${qs.toString()}`;
+    const url = `ws://${HOST}/parties/retro/${roomId}?${qs.toString()}`;
     const ws = new WebSocket(url);
     let resolved = false;
     let latestState = null;
@@ -60,7 +57,7 @@ function connect(name, userId = null) {
   });
 }
 
-function waitFor(getState, predicate, timeoutMs = 3000) {
+function waitFor(getState, predicate, timeoutMs = 4000) {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + timeoutMs;
     const check = () => {
@@ -73,106 +70,140 @@ function waitFor(getState, predicate, timeoutMs = 3000) {
   });
 }
 
-async function run() {
-  log(`Room: ${ROOM_ID}`);
+// ── Scenario 1: advance-to-voting auto-group label ──
+async function testAutoGroupLabel() {
+  log("--- Scenario 1: auto-group full label on advance-to-voting ---");
+  const roomId = `${BASE_ROOM}-s1`;
+  const fac = await connectRoom("Fac1", roomId);
 
-  const fac = await connect("Facilitator");
-  log(`Facilitator joined, id=${fac.id}`);
-
-  // Start the retro (no previous actions, goes straight to writing)
   fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "writing");
-  log("Phase: writing");
 
-  // ── Scenario 1: auto-group label on advance-to-voting ──
-  // The old code truncated the label at 40 chars for this path.
-  const longText40 = "this is a fairly long topic name that exceeds forty characters easily yes it does";
-  assert(longText40.length > 40, "test text exceeds old 40-char threshold");
+  const longText = "this is a fairly long topic name that exceeds forty characters easily";
+  assert(longText.length > 40, "test text exceeds old 40-char auto-group threshold");
 
-  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText40 }));
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText }));
   await waitFor(fac.getState, (s) => s.cards.length > 0);
 
-  // Advance to grouping, then to voting (voting auto-groups ungrouped cards)
   fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "grouping");
-  log("Phase: grouping");
 
   fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "voting");
-  log("Phase: voting");
 
   const state = fac.getState();
-  assert(state.groups.length > 0, "at least one group exists after advance-to-voting");
   const autoGroup = state.groups.find((g) => g.cardIds.length > 0);
-  assert(autoGroup !== undefined, "an auto-group was created");
+  assert(autoGroup !== undefined, "auto-group exists");
   assert(
-    autoGroup?.label === longText40,
-    `auto-group label equals full text (got "${autoGroup?.label?.slice(0, 50)}...")`
+    autoGroup?.label === longText,
+    `auto-group label is full text (got "${autoGroup?.label?.slice(0, 50)}")`
   );
 
-  // ── Scenario 2: proximity-group label in grouping phase ──
-  // Use a separate room to test proximity grouping label via a fresh retro.
-  const ROOM_2 = `${ROOM_ID}-prox`;
-  const fac2 = await connect("Facilitator2");
-  // Connect to second room separately
-  const qs2 = new URLSearchParams({ name: "Fac2" });
-  const url2 = `ws://${HOST}/parties/retro/${ROOM_2}?${qs2.toString()}`;
-  const fac2b = await new Promise((resolve, reject) => {
-    const ws = new WebSocket(url2);
-    let latestState = null;
-    let resolved = false;
-    ws.on("message", (raw) => {
-      const data = JSON.parse(raw.toString());
-      if (data.type === "sync") {
-        latestState = data.state;
-        if (!resolved) { resolved = true; resolve({ ws, id: data.you, getState: () => latestState }); }
-      } else if (data.type === "update") { latestState = data.state; }
-    });
-    ws.on("error", (err) => { if (!resolved) reject(err); });
-    setTimeout(() => { if (!resolved) reject(new Error("timeout")); }, 5000);
-  });
+  fac.ws.close();
+}
 
-  fac2b.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac2b.id }));
-  await waitFor(fac2b.getState, (s) => s.phase === "writing");
+// ── Scenario 2: proximity-group label ──
+async function testProximityGroupLabel() {
+  log("--- Scenario 2: proximity-group full label ---");
+  const roomId = `${BASE_ROOM}-s2`;
+  const fac = await connectRoom("Fac2", roomId);
 
-  const longText30 = "this topic text is longer than thirty characters absolutely";
-  assert(longText30.length > 30, "test text exceeds old 30-char proximity threshold");
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
 
-  fac2b.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText30 }));
-  await waitFor(fac2b.getState, (s) => s.cards.length > 0);
+  const longText = "this topic text is longer than thirty characters absolutely yes";
+  assert(longText.length > 30, "test text exceeds old 30-char proximity threshold");
 
-  // Advance to grouping
-  fac2b.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac2b.id }));
-  await waitFor(fac2b.getState, (s) => s.phase === "grouping");
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText }));
+  await waitFor(fac.getState, (s) => s.cards.length > 0);
 
-  // Move a card to trigger proximity grouping computation
-  const cardId = fac2b.getState().cards[0].id;
-  fac2b.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
-  await sleep(300);
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
 
-  const state2 = fac2b.getState();
-  const proxGroup = state2.groups.find((g) => g.cardIds.includes(cardId));
-  assert(proxGroup !== undefined, "proximity group contains the moved card");
+  const cardId = fac.getState().cards[0].id;
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
+  await sleep(400);
+
+  const state = fac.getState();
+  const proxGroup = state.groups.find((g) => g.cardIds.includes(cardId));
+  assert(proxGroup !== undefined, "proximity group contains the card");
   assert(
-    proxGroup?.label === longText30,
-    `proximity group label equals full text (got "${proxGroup?.label?.slice(0, 50)}...")`
+    proxGroup?.label === longText,
+    `proximity group label is full text (got "${proxGroup?.label?.slice(0, 50)}")`
   );
 
-  // ── Summary ──
+  fac.ws.close();
+}
+
+// ── Scenario 3: chip rename persists through card moves ──
+async function testChipRenamePersistedThroughMove() {
+  log("--- Scenario 3: group rename via chip persists after card move ---");
+  const roomId = `${BASE_ROOM}-s3`;
+  const fac = await connectRoom("Fac3", roomId);
+
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
+
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: "card alpha" }));
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: "card beta" }));
+  await waitFor(fac.getState, (s) => s.cards.length >= 2);
+
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
+
+  // Move two cards close together to form a proximity group
+  const cards = fac.getState().cards;
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[0].id, x: 100, y: 100 }));
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[1].id, x: 140, y: 120 }));
+  await sleep(400);
+
+  const groupsBefore = fac.getState().groups;
+  assert(groupsBefore.length > 0, "groups formed by proximity");
+
+  const groupId = groupsBefore[0].id;
+  const newLabel = "Our renamed group via chip";
+
+  // Send the same RENAME_GROUP event the chip calls through onRenameGroup
+  fac.ws.send(JSON.stringify({ type: "RENAME_GROUP", groupId, label: newLabel }));
+  await waitFor(fac.getState, (s) => s.groups.some((g) => g.id === groupId && g.label === newLabel));
+
+  assert(
+    fac.getState().groups.find((g) => g.id === groupId)?.label === newLabel,
+    "label updated to chip-renamed value"
+  );
+
+  // Move a card slightly: proximity recomputes, but renamedLabels fingerprint should restore the label
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[0].id, x: 110, y: 105 }));
+  await sleep(400);
+
+  const labelAfterMove = fac.getState().groups.find((g) =>
+    g.cardIds.includes(cards[0].id) || g.cardIds.includes(cards[1].id)
+  )?.label;
+  assert(
+    labelAfterMove === newLabel,
+    `label persists after card move (got "${labelAfterMove}")`
+  );
+
+  fac.ws.close();
+}
+
+async function run() {
+  log(`Base room: ${BASE_ROOM}`);
+
+  await testAutoGroupLabel();
+  await testProximityGroupLabel();
+  await testChipRenamePersistedThroughMove();
+
   log("=".repeat(50));
-  log("GROUP LABEL TESTS COMPLETE");
+  log("GROUP LABEL + CHIP RENAME TESTS COMPLETE");
   log("=".repeat(50));
   if (failures === 0) {
     log("ALL CHECKS PASSED");
+    process.exit(0);
   } else {
     log(`${failures} CHECK(S) FAILED`);
+    process.exit(1);
   }
-
-  try { fac.ws.close(); } catch {}
-  try { fac2.ws.close(); } catch {}
-  try { fac2b.ws.close(); } catch {}
-
-  process.exit(failures === 0 ? 0 : 1);
 }
 
 run().catch((err) => {

--- a/tests/retro-typing-indicator.mjs
+++ b/tests/retro-typing-indicator.mjs
@@ -1,0 +1,161 @@
+/**
+ * Anonymous typing indicator tests.
+ *
+ * Two scenarios:
+ *   1. Participant A starts typing. Participant B receives a typing_update with
+ *      participantIds containing A's id. A stops typing. B's indicator clears.
+ *      Names must never appear in any typing_update broadcast.
+ *   2. A disconnects mid-typing. B's typing indicator clears within one tick.
+ *
+ * Usage: node tests/retro-typing-indicator.mjs [host] [roomId]
+ *
+ * Requires a running PartyKit dev server and the "ws" npm package.
+ */
+
+import WebSocket from "ws";
+
+const HOST = process.argv[2] || "127.0.0.1:1999";
+const BASE_ROOM = process.argv[3] || `typing-${Date.now().toString(36)}`;
+
+const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+function assert(condition, msg) {
+  if (condition) {
+    log(`PASS: ${msg}`);
+  } else {
+    log(`FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+function connectRoom(name, roomId) {
+  return new Promise((resolve, reject) => {
+    const qs = new URLSearchParams({ name });
+    const url = `ws://${HOST}/parties/retro/${roomId}?${qs.toString()}`;
+    const ws = new WebSocket(url);
+    let resolved = false;
+    let latestState = null;
+    let latestTypingIds = [];
+    const typingUpdates = [];
+
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) {
+          resolved = true;
+          resolve({
+            ws,
+            id: data.you,
+            name,
+            getState: () => latestState,
+            getTypingIds: () => latestTypingIds,
+            getTypingUpdates: () => typingUpdates,
+          });
+        }
+      } else if (data.type === "update") {
+        latestState = data.state;
+      } else if (data.type === "typing_update") {
+        latestTypingIds = data.participantIds;
+        typingUpdates.push({ participantIds: [...data.participantIds], ts: Date.now() });
+      }
+    });
+
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error(`Timeout for "${name}"`)); }, 5000);
+  });
+}
+
+function waitFor(getVal, predicate, timeoutMs = 4000) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      const val = getVal();
+      if (predicate(val)) return resolve(val);
+      if (Date.now() > deadline) return reject(new Error("waitFor timeout"));
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+// ── Scenario 1: A types, B sees indicator; A stops, indicator clears; no names in broadcast ──
+async function testTypingIndicatorBasic() {
+  log("--- Scenario 1: typing indicator appears and clears ---");
+  const roomId = `${BASE_ROOM}-s1`;
+  const a = await connectRoom("Alice", roomId);
+  const b = await connectRoom("Bob", roomId);
+  log(`A=${a.id} B=${b.id}`);
+
+  // Send TYPING_START from A
+  a.ws.send(JSON.stringify({ type: "TYPING_START" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length > 0);
+
+  const idsAfterStart = b.getTypingIds();
+  assert(idsAfterStart.includes(a.id), "B sees A's participantId in typing_update");
+  assert(!idsAfterStart.includes("Alice"), "B does not see A's name in typing_update");
+
+  // Verify no name appears in any typing_update B has received
+  const allUpdates = b.getTypingUpdates();
+  const nameLeaked = allUpdates.some((u) =>
+    u.participantIds.some((id) => id === "Alice" || id === "Bob")
+  );
+  assert(!nameLeaked, "No name (Alice/Bob) appeared in any typing_update broadcast");
+
+  // Send TYPING_STOP from A
+  a.ws.send(JSON.stringify({ type: "TYPING_STOP" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length === 0);
+
+  assert(b.getTypingIds().length === 0, "indicator clears after TYPING_STOP");
+
+  a.ws.close();
+  b.ws.close();
+}
+
+// ── Scenario 2: A disconnects mid-typing; B's indicator clears ──
+async function testTypingClearsOnDisconnect() {
+  log("--- Scenario 2: indicator clears when typer disconnects ---");
+  const roomId = `${BASE_ROOM}-s2`;
+  const a = await connectRoom("Alice2", roomId);
+  const b = await connectRoom("Bob2", roomId);
+
+  // A starts typing but does not stop
+  a.ws.send(JSON.stringify({ type: "TYPING_START" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length > 0);
+  assert(b.getTypingIds().includes(a.id), "B sees A typing before disconnect");
+
+  // A disconnects without sending TYPING_STOP
+  a.ws.close();
+
+  // B's indicator should clear when the server processes onClose
+  await waitFor(b.getTypingIds, (ids) => ids.length === 0, 5000);
+  assert(b.getTypingIds().length === 0, "indicator clears after A disconnects mid-typing");
+
+  b.ws.close();
+}
+
+async function run() {
+  log(`Base room: ${BASE_ROOM}`);
+
+  await testTypingIndicatorBasic();
+  await sleep(200);
+  await testTypingClearsOnDisconnect();
+
+  log("=".repeat(50));
+  log("TYPING INDICATOR TESTS COMPLETE");
+  log("=".repeat(50));
+  if (failures === 0) {
+    log("ALL CHECKS PASSED");
+    process.exit(0);
+  } else {
+    log(`${failures} CHECK(S) FAILED`);
+    process.exit(1);
+  }
+}
+
+run().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
Six retro phase fixes uncovered during a real production retro on 2026-04-30. Stacks on PR #11 (silent-failure hardening). Merge #11 first or rebase this onto main after merge.

## Fixes

- **Fix 1** — `src/lib/state-machines/retro.ts` lines 287, 651: remove 40-char and 30-char truncation on auto-generated group labels. Both the advance-to-voting path and `computeProximityGroups` now use the full card text. `discuss-act-phase.tsx` line 160: added `min-w-0` + `break-words` so long labels wrap rather than push the vote pill off-screen.
- **Fix 2** — `src/components/retro/grouping-phase.tsx` line 241: removed `line-clamp-4` from card text span. Cards in the grouping canvas now grow vertically with content.
- **Fix 3** — `src/components/retro/grouping-phase.tsx`: group summary chips below the canvas converted from read-only `<span>` to `RenameableChip` buttons. Each chip shows an `EditPencil` icon and opens an inline input on click, using the same `onRenameGroup` handler as the canvas boundary rename.
- **Fix 4** — `src/components/retro/voting-phase.tsx`: moved "Start discussion" button from the bottom of the page into the dashed-border voting progress block at the top (appears right after the participant status row). Removed the bottom render. The subtle "Force reveal" link stays at the bottom for the not-all-voted case.
- **Fix 5** — `party/retro.ts`, `src/hooks/use-retro-room.ts`, `src/components/retro/writing-phase.tsx`: anonymous "Someone is typing..." indicator. Server tracks participantIds (never names) in an ephemeral `Set`, broadcasts `typing_update` on `TYPING_START` / `TYPING_STOP`, and clears on disconnect. Client debounces `TYPING_STOP` 3s after last keystroke, clears on submit and unmount. Renders a pulsing dot + dim text when `typingOthers > 0`. No name is ever shown. The typing indicator was previously deliberately removed; this re-adds it in anonymous-only form.
- **Fix 6** — `party/retro.ts` `onClose`: facilitator role is now sticky to the room creator. When the creator disconnects, `facilitatorId` stays pointing to their (now-disconnected) participantId rather than falling back to the next connected participant. The `reclaim-on-join` logic from PR #11 restores the role when they reconnect.

## Tests

- `tests/retro-group-labels.mjs` (3 scenarios): auto-group full label, proximity-group full label, chip rename persists through card moves.
- `tests/retro-typing-indicator.mjs` (2 scenarios): A types, B sees indicator with participantId (no name); A stops, indicator clears. A disconnects mid-type, B's indicator clears.
- `tests/retro-facilitator-promotion.mjs` (updated): scenario 3 now asserts facilitatorId stays as creator's id after disconnect (was incorrectly asserting fallback to A).

## Typecheck

`npx tsc --noEmit` passes with only the pre-existing `.next/types/routes.d.ts` duplicate-identifier artifact (not introduced by this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)