### PR TITLE
fix: retro phase UX, anonymous typing, closed-retro summary, pricing route (rolls up PR #12)

### DIFF
--- a/party/retro.ts
+++ b/party/retro.ts
@@ -14,8 +14,10 @@ import {
  * transition(), broadcasts new state. Server is single source of truth.
  *
  * ANONYMITY: During writing phase, the server strips the sender's
- * real identity and assigns a random anonymousId. The mapping is
- * NEVER broadcast. No typing indicators are sent.
+ * real identity and assigns a random anonymousId. The mapping is NEVER
+ * broadcast. Typing indicators are ephemeral: only participantIds are
+ * broadcast (never names), and clients filter their own ID before showing
+ * the indicator. Typing state is never persisted to storage.
  */
 
 interface ConnectionState {
@@ -32,6 +34,8 @@ function generateId(): string {
 export default class RetroServer implements Party.Server {
   state: RetroState;
   timerInterval: ReturnType<typeof setInterval> | null = null;
+  /** Ephemeral set of participantIds currently typing. Never persisted. */
+  private typingParticipants: Set<string> = new Set();
 
   constructor(readonly room: Party.Room) {
     this.state = createInitialState("");
@@ -138,6 +142,18 @@ export default class RetroServer implements Party.Server {
       return;
     }
 
+    // ── Typing indicators (ephemeral, never persisted, never includes names) ──
+    if (parsed.type === "TYPING_START") {
+      this.typingParticipants.add(connState.participantId);
+      this.broadcastTyping();
+      return;
+    }
+    if (parsed.type === "TYPING_STOP") {
+      this.typingParticipants.delete(connState.participantId);
+      this.broadcastTyping();
+      return;
+    }
+
     let event = parsed as RetroEvent;
 
     // ── Anonymity enforcement for ADD_CARD ──
@@ -211,17 +227,32 @@ export default class RetroServer implements Party.Server {
   async onClose(conn: Party.Connection) {
     const connState = conn.state as ConnectionState | undefined;
     if (connState) {
+      // Remove from typing set and broadcast if they were typing when they disconnected
+      if (this.typingParticipants.has(connState.participantId)) {
+        this.typingParticipants.delete(connState.participantId);
+        this.broadcastTyping();
+      }
+
       this.state = transition(this.state, {
         type: "PARTICIPANT_LEAVE",
         participantId: connState.participantId,
       });
 
-      // Reassign facilitator if needed
+      // Fix 6: if the leaving participant is the room creator, keep facilitatorId
+      // as-is and wait for the creator to reconnect (reclaim-on-join handles return).
+      // Only reassign if the leaver is a non-creator facilitator.
       if (this.state.facilitatorId === connState.participantId) {
-        const next = this.getFirstConnectedParticipantId(connState.participantId);
-        if (next) {
-          this.state = { ...this.state, facilitatorId: next };
+        const isCreator =
+          connState.userId !== null && connState.userId === this.state.createdBy;
+        if (!isCreator) {
+          const next = this.getFirstConnectedParticipantId(connState.participantId);
+          if (next) {
+            this.state = { ...this.state, facilitatorId: next };
+          }
         }
+        // If the creator is leaving, facilitatorId intentionally keeps pointing to their
+        // (now disconnected) participantId. The reclaim-on-join logic in onConnect will
+        // restore it when they reconnect.
       }
 
       await this.persist();
@@ -329,6 +360,15 @@ export default class RetroServer implements Party.Server {
 
   private broadcast() {
     const message = JSON.stringify({ type: "update", state: this.state });
+    this.room.broadcast(message);
+  }
+
+  /** Broadcast the current typing set to all connections. Never includes names. */
+  private broadcastTyping() {
+    const message = JSON.stringify({
+      type: "typing_update",
+      participantIds: Array.from(this.typingParticipants),
+    });
     this.room.broadcast(message);
   }
 

--- a/src/app/(app)/retro/[id]/page.tsx
+++ b/src/app/(app)/retro/[id]/page.tsx
@@ -161,6 +161,9 @@ function RetroRoom({
     removeActionItem,
     updateActionItem,
     closeRetro,
+    typingOthers,
+    startTyping,
+    stopTyping,
   } = useRetroRoom({ roomId, playerName, clerkUserId });
 
   // Unresolved items from previous retro (groups without action items)
@@ -292,6 +295,9 @@ function RetroRoom({
             isFacilitator={isFacilitator}
             onAdvance={advancePhase}
             participantCount={state.participants.length}
+            typingOthers={typingOthers}
+            onStartTyping={startTyping}
+            onStopTyping={stopTyping}
           />
         )}
 

--- a/src/app/(app)/retro/[id]/page.tsx
+++ b/src/app/(app)/retro/[id]/page.tsx
@@ -1,670 +1,98 @@
-"use client";
+import { getDb } from "@/lib/db";
+import {
+  retros,
+  retroGroups,
+  retroCards,
+  actionItems,
+} from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import {
+  ClosedRetroSummary,
+  type ClosedRetroSummaryProps,
+} from "@/components/retro/closed-retro-summary";
+import { RetroRoomClient } from "./retro-room-client";
 
-import { useState, useCallback, useMemo, useEffect, use } from "react";
-import { useSearchParams } from "next/navigation";
-import { useUser, useAuth } from "@clerk/nextjs";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Skeleton } from "@/components/ui/skeleton";
-import { ThemeToggle } from "@/components/shared/theme-toggle";
-import { GhostIcon, OwlIcon } from "@/components/shared/icons";
-import { ConnectionStatus } from "@/components/shared/connection-status";
-import { PhaseIndicator } from "@/components/retro/phase-indicator";
-import { HauntingPhase } from "@/components/retro/haunting-phase";
-import { WritingPhase } from "@/components/retro/writing-phase";
-import { GroupingPhase } from "@/components/retro/grouping-phase";
-import { VotingPhase } from "@/components/retro/voting-phase";
-import { DiscussActPhase } from "@/components/retro/discuss-act-phase";
-import { useRetroRoom } from "@/hooks/use-retro-room";
-import { getRetroStats, type RetroState, type CardGroup } from "@/lib/state-machines/retro";
-import { cn } from "@/lib/utils";
-import Link from "next/link";
-import { NavArrowLeft, LogOut, Copy, Check, Download } from "iconoir-react";
-import { generateCSV, downloadCSV } from "@/lib/csv";
-
-export default function RetroRoomPage({
+export default async function RetroRoomPage({
   params,
 }: {
   params: Promise<{ id: string }>;
 }) {
-  const { id: roomId } = use(params);
-  const searchParams = useSearchParams();
-  const teamId = searchParams.get("team") ?? undefined;
-  const [playerName, setPlayerName] = useState("");
-  const [joined, setJoined] = useState(false);
+  const { id: roomCode } = await params;
 
-  if (!joined) {
-    return (
-      <JoinScreen
-        name={playerName}
-        onNameChange={setPlayerName}
-        onJoin={() => setJoined(true)}
-      />
-    );
-  }
+  // Check whether this retro is closed before rendering the live room.
+  // If the DB query fails or returns nothing, fall through to the live room.
+  let closedSummaryProps: ClosedRetroSummaryProps | null = null;
 
-  return (
-    <RetroRoom
-      roomId={roomId}
-      teamId={teamId}
-      playerName={playerName}
-      onLeave={() => {
-        setJoined(false);
-        setPlayerName("");
-      }}
-    />
-  );
-}
+  try {
+    const db = getDb();
 
-// ── Join Screen ──
+    const [retro] = await db
+      .select()
+      .from(retros)
+      .where(eq(retros.roomCode, roomCode))
+      .limit(1);
 
-function JoinScreen({
-  name,
-  onNameChange,
-  onJoin,
-}: {
-  name: string;
-  onNameChange: (name: string) => void;
-  onJoin: () => void;
-}) {
-  return (
-    <div className="flex min-h-svh flex-col px-4">
-      <div className="px-2 py-5 sm:px-8">
-        <Link
-          href="/"
-          className="inline-flex items-center gap-1.5 text-sm font-bold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
-        >
-          <NavArrowLeft width={16} height={16} />
-          Back
-        </Link>
-      </div>
+    if (retro?.status === "closed") {
+      const groups = await db
+        .select()
+        .from(retroGroups)
+        .where(eq(retroGroups.retroId, retro.id));
 
-      <div className="stagger-in mx-auto flex flex-1 w-full max-w-sm flex-col items-center justify-center space-y-8 text-center">
-        <div className="mx-auto flex h-24 w-24 items-center justify-center rounded-md border-2 border-coffee/40 bg-coffee/10 text-coffee shadow-hard">
-          <GhostIcon size={52} />
-        </div>
+      const cards = await db
+        .select()
+        .from(retroCards)
+        .where(eq(retroCards.retroId, retro.id));
 
-        <div>
-          <h1 className="font-display text-4xl tracking-ceremony sm:text-5xl">
-            Retro
-          </h1>
-          <p className="mt-2 text-sm font-medium text-muted-foreground">
-            Enter your name to join the room.
-          </p>
-        </div>
+      const actions = await db
+        .select()
+        .from(actionItems)
+        .where(eq(actionItems.retroId, retro.id));
 
-        <div className="space-y-3">
-          <Input
-            value={name}
-            onChange={(e) => onNameChange(e.target.value)}
-            placeholder="Your name"
-            onKeyDown={(e) => e.key === "Enter" && name.trim() && onJoin()}
-            autoFocus
-            className="h-12 border-2 border-border bg-card text-center font-bold shadow-hard placeholder:text-muted-foreground/50 focus:border-coffee"
-          />
-          <Button
-            onClick={onJoin}
-            disabled={!name.trim()}
-            className="h-12 w-full"
-            size="lg"
-          >
-            Join retro
-          </Button>
-        </div>
-      </div>
-    </div>
-  );
-}
+      const summaryGroups = groups.map((g) => ({
+        id: g.id,
+        label: g.label,
+        voteCount: g.voteCount ?? 0,
+        rank: g.rank,
+        cards: cards
+          .filter((c) => c.groupId === g.id)
+          .map((c) => ({
+            id: c.id,
+            text: c.text,
+            category: c.category,
+          })),
+        actionItems: actions
+          .filter((a) => a.groupId === g.id)
+          .map((a) => ({
+            id: a.id,
+            text: a.text,
+            assignees: (a.assignees as string[]) ?? [],
+            groupId: a.groupId,
+          })),
+      }));
 
-// ── Retro Room ──
+      const generalActionItems = actions
+        .filter((a) => a.groupId === null)
+        .map((a) => ({
+          id: a.id,
+          text: a.text,
+          assignees: (a.assignees as string[]) ?? [],
+          groupId: null,
+        }));
 
-function RetroRoom({
-  roomId,
-  teamId,
-  playerName,
-  onLeave,
-}: {
-  roomId: string;
-  teamId?: string;
-  playerName: string;
-  onLeave: () => void;
-}) {
-  const { userId: clerkUserId } = useAuth();
-
-  const {
-    state,
-    myId,
-    myAnonymousId,
-    isFacilitator,
-    connected,
-    startRetro,
-    markAction,
-    advancePhase,
-    addCard,
-    editCard,
-    removeCard,
-    moveCardPosition,
-    scatterCards,
-    sendCursor,
-    cursors,
-    createGroup,
-    renameGroup,
-    moveCardToGroup,
-    removeCardFromGroup,
-    castVote,
-    removeVote,
-    myVoteCount,
-    setTimer,
-    toggleTimer,
-    nextTopic,
-    addActionItem,
-    removeActionItem,
-    updateActionItem,
-    closeRetro,
-    typingOthers,
-    startTyping,
-    stopTyping,
-  } = useRetroRoom({ roomId, playerName, clerkUserId });
-
-  // Unresolved items from previous retro (groups without action items)
-  const [unresolvedItems, setUnresolvedItems] = useState<ReadonlyArray<{ id: string; label: string; category?: string; voteCount?: number }>>([]);
-
-  const myVotesByGroup = useMemo(() => {
-    if (!state || !myId) return new Map<string, number>();
-    const map = new Map<string, number>();
-    for (const vote of state.votes) {
-      if (vote.odiedId === myId) {
-        map.set(vote.groupId, (map.get(vote.groupId) ?? 0) + 1);
-      }
+      closedSummaryProps = {
+        roomCode,
+        closedAt: retro.closedAt,
+        groups: summaryGroups,
+        generalActionItems,
+      };
     }
-    return map;
-  }, [state, myId]);
-
-  // Loading state
-  if (!state) {
-    return (
-      <div className="mx-auto flex min-h-svh max-w-3xl flex-col px-4 py-8">
-        <ConnectionStatus connected={connected} hasState={false} />
-        {connected && (
-          <>
-            <Skeleton className="h-8 w-48" />
-            <Skeleton className="mt-4 h-4 w-32" />
-            <div className="mt-12 space-y-4">
-              <Skeleton className="h-20 w-full" />
-              <Skeleton className="h-20 w-full" />
-            </div>
-          </>
-        )}
-      </div>
-    );
+  } catch {
+    // DB unavailable or no row found: fall through to the live room
   }
 
-  return (
-    <div className="mx-auto flex min-h-svh max-w-4xl flex-col px-4 py-6 sm:py-8">
-      <ConnectionStatus connected={connected} hasState={!!state} />
-      {/* Header */}
-      <header className="flex items-center justify-between">
-        <div>
-          <div className="flex items-baseline gap-3">
-            <Link
-              href="/"
-              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border-2 border-border bg-card text-muted-foreground shadow-hard-sm transition-colors hover:border-foreground/40 hover:text-foreground"
-              aria-label="Back to home"
-            >
-              <NavArrowLeft width={16} height={16} />
-            </Link>
-            <h1 className="font-display text-3xl tracking-ceremony sm:text-4xl">
-              Retro
-            </h1>
-          </div>
-          <div className="mt-1 flex items-center gap-2">
-            <span className="text-xs font-bold text-muted-foreground">
-              {state.participants.length} participant
-              {state.participants.length !== 1 ? "s" : ""}
-            </span>
-            <span
-              className={cn(
-                "inline-block h-2 w-2 rounded-full",
-                connected ? "bg-success" : "bg-destructive animate-pulse"
-              )}
-            />
-            {isFacilitator && (
-              <span className="rounded-md bg-coffee/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-coffee">
-                Facilitator
-              </span>
-            )}
-          </div>
-        </div>
-        <div className="flex items-center gap-3">
-          {state.phase !== "lobby" && state.phase !== "closed" && (
-            <div className="hidden sm:block">
-              <PhaseIndicator phase={state.phase} />
-            </div>
-          )}
-          <button
-            onClick={onLeave}
-            className="inline-flex items-center gap-1.5 text-xs font-bold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
-          >
-            <LogOut width={14} height={14} />
-            Leave
-          </button>
-          <ThemeToggle />
-        </div>
-      </header>
-
-      {/* Mobile phase indicator */}
-      {state.phase !== "lobby" && state.phase !== "closed" && (
-        <div className="mt-3 overflow-x-auto sm:hidden">
-          <PhaseIndicator phase={state.phase} />
-        </div>
-      )}
-
-      {/* Divider */}
-      <div className="my-5 h-0.5 bg-border" />
-
-      {/* Phase content */}
-      <div className="flex-1">
-        {state.phase === "lobby" && (
-          <LobbyPhase
-            teamId={teamId}
-            isFacilitator={isFacilitator}
-            participantCount={state.participants.length}
-            participants={state.participants}
-            onStart={startRetro}
-            onUnresolvedItems={setUnresolvedItems}
-          />
-        )}
-
-        {state.phase === "haunting" && (
-          <HauntingPhase
-            actions={state.previousActions}
-            unresolvedItems={unresolvedItems}
-            isFacilitator={isFacilitator}
-            onMark={markAction}
-            onAdvance={advancePhase}
-          />
-        )}
-
-        {state.phase === "writing" && (
-          <WritingPhase
-            cards={state.cards}
-            myAnonymousId={myAnonymousId}
-            onAddCard={addCard}
-            onEditCard={editCard}
-            onRemoveCard={removeCard}
-            isFacilitator={isFacilitator}
-            onAdvance={advancePhase}
-            participantCount={state.participants.length}
-            typingOthers={typingOthers}
-            onStartTyping={startTyping}
-            onStopTyping={stopTyping}
-          />
-        )}
-
-        {state.phase === "grouping" && (
-          <GroupingPhase
-            cards={state.cards}
-            groups={state.groups}
-            cardPositions={state.cardPositions}
-            cursors={cursors}
-            myId={myId}
-            isFacilitator={isFacilitator}
-            onMoveCard={moveCardPosition}
-            onScatterCards={scatterCards}
-            onSendCursor={sendCursor}
-            onRenameGroup={renameGroup}
-            onAdvance={advancePhase}
-          />
-        )}
-
-        {state.phase === "voting" && (
-          <VotingPhase
-            groups={state.groups}
-            cards={state.cards}
-            participants={state.participants}
-            votes={state.votes}
-            myVoteCount={myVoteCount}
-            maxVotes={state.maxVotesPerPerson}
-            myVotesByGroup={myVotesByGroup}
-            isFacilitator={isFacilitator}
-            onVote={castVote}
-            onRemoveVote={removeVote}
-            onAdvance={advancePhase}
-          />
-        )}
-
-        {(state.phase === "discussing" || state.phase === "committing") && (
-          <DiscussActPhase
-            groups={state.groups}
-            cards={state.cards}
-            rankedGroupIds={state.rankedGroupIds}
-            actionItems={state.actionItems}
-            participants={state.participants}
-            isFacilitator={isFacilitator}
-            onAddItem={(text, assignees, groupId) =>
-              addActionItem(text, assignees, groupId)
-            }
-            onRemoveItem={removeActionItem}
-            onClose={closeRetro}
-          />
-        )}
-
-        {state.phase === "closed" && (
-          <ClosedPhase state={state} onDone={onLeave} />
-        )}
-      </div>
-    </div>
-  );
-}
-
-// ── Lobby Phase ──
-
-function LobbyPhase({
-  teamId,
-  isFacilitator,
-  participantCount,
-  participants,
-  onStart,
-  onUnresolvedItems,
-}: {
-  teamId?: string;
-  isFacilitator: boolean;
-  participantCount: number;
-  participants: ReadonlyArray<{ id: string; name: string }>;
-  onStart: (options?: { teamId?: string; createdBy?: string; previousActions?: ReadonlyArray<import("@/lib/state-machines/retro").PreviousAction> }) => void;
-  onUnresolvedItems: (items: ReadonlyArray<{ id: string; label: string; category?: string; voteCount?: number }>) => void;
-}) {
-  const { user } = useUser();
-  const [previousActions, setPreviousActions] = useState<ReadonlyArray<import("@/lib/state-machines/retro").PreviousAction>>([]);
-  const [loadingActions, setLoadingActions] = useState(false);
-  const [loaded, setLoaded] = useState(false);
-
-  // Fetch previous retro data when facilitator joins (requires a real team ID)
-  useEffect(() => {
-    if (!isFacilitator || !teamId || loaded) return;
-    setLoadingActions(true);
-    fetch(`/api/retros/previous-actions?teamId=${teamId}`)
-      .then((res) => res.json())
-      .then((data) => {
-        if (data.actions?.length > 0) {
-          setPreviousActions(
-            data.actions.map((a: { id: string; text: string; assignees: string[]; done: boolean }) => ({
-              id: a.id,
-              text: a.text,
-              assignees: a.assignees ?? [],
-              done: a.done,
-            }))
-          );
-        }
-        // Collect unresolved items: groups without action items
-        const unresolved: Array<{ id: string; label: string; category?: string; voteCount?: number }> = [];
-        if (data.groups?.length > 0) {
-          for (const g of data.groups as Array<{ id: string; label: string; voteCount: number; hasActions: boolean }>) {
-            if (!g.hasActions) {
-              unresolved.push({ id: g.id, label: g.label, voteCount: g.voteCount });
-            }
-          }
-        }
-        onUnresolvedItems(unresolved);
-      })
-      .catch(() => {}) // DB might not be set up yet, that's OK
-      .finally(() => {
-        setLoadingActions(false);
-        setLoaded(true);
-      });
-  }, [isFacilitator, teamId, loaded, onUnresolvedItems]);
-
-  const handleStart = () => {
-    onStart({
-      teamId,
-      createdBy: user?.id,
-      previousActions: previousActions.length > 0 ? previousActions : undefined,
-    });
-  };
-
-  return (
-    <div className="stagger-in mx-auto max-w-md space-y-6 text-center">
-      <div className="flex justify-center text-coffee">
-        <GhostIcon size={64} />
-      </div>
-      <div>
-        <h2 className="font-display text-3xl tracking-ceremony">
-          Ready for retro?
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          {participantCount} participant{participantCount !== 1 ? "s" : ""}{" "}
-          in the room
-        </p>
-      </div>
-
-      {/* Participant list */}
-      <div className="flex flex-wrap justify-center gap-2">
-        {participants.map((p) => (
-          <span
-            key={p.id}
-            className="rounded-md border-2 border-border bg-card px-3 py-1.5 text-xs font-bold shadow-hard-sm"
-          >
-            {p.name}
-          </span>
-        ))}
-      </div>
-
-      {/* Previous actions preview */}
-      {previousActions.length > 0 && (
-        <div className="rounded-md border-2 border-coffee/30 bg-coffee/5 p-3 text-left">
-          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-coffee mb-2">
-            <GhostIcon size={12} className="inline mr-1" />
-            {previousActions.length} action item{previousActions.length !== 1 ? "s" : ""} from last retro
-          </p>
-          {previousActions.slice(0, 3).map((a) => (
-            <p key={a.id} className="text-xs text-muted-foreground truncate">
-              {a.done ? "Done" : "Pending"}: {a.text}
-            </p>
-          ))}
-          {previousActions.length > 3 && (
-            <p className="text-xs text-muted-foreground">
-              +{previousActions.length - 3} more...
-            </p>
-          )}
-        </div>
-      )}
-
-      {isFacilitator ? (
-        <Button
-          onClick={handleStart}
-          disabled={loadingActions}
-          className="h-12"
-          size="lg"
-        >
-          {loadingActions ? "Loading previous actions..." : "Start retro"}
-        </Button>
-      ) : (
-        <p className="text-xs font-bold text-muted-foreground">
-          Waiting for facilitator to start...
-        </p>
-      )}
-    </div>
-  );
-}
-
-// ── Closed Phase ──
-
-function ClosedPhase({
-  state,
-  onDone,
-}: {
-  state: RetroState;
-  onDone: () => void;
-}) {
-  const [copied, setCopied] = useState(false);
-  const stats = getRetroStats(state);
-
-  // Build summary text grouped by topic
-  const rankedGroups = state.rankedGroupIds
-    .map((id) => state.groups.find((g) => g.id === id))
-    .filter(Boolean) as ReadonlyArray<CardGroup>;
-  const allGroups = [
-    ...rankedGroups,
-    ...state.groups.filter((g) => !state.rankedGroupIds.includes(g.id)),
-  ];
-
-  const summaryLines: string[] = [
-    "Retro Summary",
-    "=".repeat(40),
-    `Cards: ${stats.totalCards} | Groups: ${stats.groupCount} | Actions: ${stats.actionCount}`,
-    "",
-  ];
-  for (const group of allGroups) {
-    const actions = state.actionItems.filter((a) => a.groupId === group.id);
-    summaryLines.push(`## ${group.label} (${group.voteCount} votes)`);
-    for (const a of actions) {
-      summaryLines.push(`  - [ ] ${a.text}${a.assignees.length > 0 ? ` (${a.assignees.join(", ")})` : ""}`);
-    }
-    summaryLines.push("");
+  if (closedSummaryProps) {
+    return <ClosedRetroSummary {...closedSummaryProps} />;
   }
-  const generalActions = state.actionItems.filter((a) => !a.groupId);
-  if (generalActions.length > 0) {
-    summaryLines.push("## General");
-    for (const a of generalActions) {
-      summaryLines.push(`  - [ ] ${a.text}${a.assignees.length > 0 ? ` (${a.assignees.join(", ")})` : ""}`);
-    }
-  }
-  const summaryText = summaryLines.join("\n");
 
-  const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(summaryText).then(() => {
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    });
-  }, [summaryText]);
-
-  const handleDownloadCSV = useCallback(() => {
-    const csv = generateCSV(
-      ["Action Item", "Assignees", "Topic", "Votes"],
-      state.actionItems.map((item) => {
-        const group = state.groups.find((g) => g.id === item.groupId);
-        return [
-          item.text,
-          item.assignees.join("; "),
-          group?.label ?? "General",
-          String(group?.voteCount ?? 0),
-        ];
-      })
-    );
-    downloadCSV(csv, `retro-actions-${new Date().toISOString().slice(0, 10)}.csv`);
-  }, [state]);
-
-  return (
-    <div className="stagger-in mx-auto max-w-2xl space-y-6">
-      {/* Header */}
-      <div className="text-center">
-        <GhostIcon size={64} className="mx-auto text-coffee" />
-        <h2 className="mt-4 font-display text-3xl tracking-ceremony sm:text-4xl">
-          Retro complete
-        </h2>
-        <p className="mt-2 text-sm text-muted-foreground">
-          Great session. Here's your snapshot.
-        </p>
-      </div>
-
-      {/* Stats */}
-      <div className="flex justify-center gap-4">
-        <StatBox value={stats.totalCards} label="cards" />
-        <StatBox value={stats.groupCount} label="groups" />
-        <StatBox value={stats.actionCount} label="actions" />
-      </div>
-
-      {/* Snapshot: Topics + Action Items */}
-      {allGroups.map((group, i) => {
-        const actions = state.actionItems.filter((a) => a.groupId === group.id);
-        if (group.voteCount === 0 && actions.length === 0) return null;
-        return (
-          <div key={group.id} className="rounded-md border-2 border-border bg-card p-4 shadow-hard-sm">
-            <div className="flex items-center justify-between">
-              <div className="flex items-center gap-2">
-                <span className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/15 font-mono text-[10px] font-bold text-primary">
-                  {i + 1}
-                </span>
-                <h3 className="text-sm font-bold">{group.label}</h3>
-              </div>
-              <span className="font-mono text-xs text-muted-foreground">
-                {group.voteCount} vote{group.voteCount !== 1 ? "s" : ""}
-              </span>
-            </div>
-            {actions.length > 0 && (
-              <div className="mt-3 space-y-1.5">
-                {actions.map((item) => (
-                  <div key={item.id} className="flex items-start gap-2 text-sm">
-                    <GhostIcon size={14} className="mt-0.5 shrink-0 text-coffee" />
-                    <div>
-                      <span className="font-medium">{item.text}</span>
-                      {item.assignees.length > 0 && (
-                        <span className="ml-1.5 text-xs text-muted-foreground">
-                          ({item.assignees.join(", ")})
-                        </span>
-                      )}
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        );
-      })}
-
-      {/* General actions */}
-      {generalActions.length > 0 && (
-        <div className="rounded-md border-2 border-dashed border-border bg-muted/20 p-4">
-          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground mb-2">
-            General action items
-          </p>
-          {generalActions.map((item) => (
-            <div key={item.id} className="flex items-start gap-2 text-sm mb-1.5">
-              <GhostIcon size={14} className="mt-0.5 shrink-0 text-coffee" />
-              <span className="font-medium">{item.text}</span>
-              {item.assignees.length > 0 && (
-                <span className="text-xs text-muted-foreground">
-                  ({item.assignees.join(", ")})
-                </span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-
-      {/* Actions */}
-      <div className="flex flex-col gap-3 pt-2">
-        <div className="grid grid-cols-2 gap-3">
-          <Button onClick={handleCopy} variant="outline">
-            {copied ? (
-              <><Check width={16} height={16} /> Copied!</>
-            ) : (
-              <><Copy width={16} height={16} /> Copy summary</>
-            )}
-          </Button>
-          {state.actionItems.length > 0 && (
-            <Button onClick={handleDownloadCSV} variant="outline">
-              <Download width={16} height={16} />
-              Export actions
-            </Button>
-          )}
-        </div>
-        <Button onClick={onDone} className="w-full">
-          Done
-        </Button>
-      </div>
-    </div>
-  );
+  return <RetroRoomClient params={params} />;
 }
-
-function StatBox({ value, label }: { value: number; label: string }) {
-  return (
-    <div className="rounded-md bg-muted px-4 py-3 text-center">
-      <p className="font-mono text-2xl font-bold">{value}</p>
-      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
-        {label}
-      </p>
-    </div>
-  );
-}
-

--- a/src/app/(app)/retro/[id]/retro-room-client.tsx
+++ b/src/app/(app)/retro/[id]/retro-room-client.tsx
@@ -1,0 +1,670 @@
+"use client";
+
+import { useState, useCallback, useMemo, useEffect, use } from "react";
+import { useSearchParams } from "next/navigation";
+import { useUser, useAuth } from "@clerk/nextjs";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+import { ThemeToggle } from "@/components/shared/theme-toggle";
+import { GhostIcon, OwlIcon } from "@/components/shared/icons";
+import { ConnectionStatus } from "@/components/shared/connection-status";
+import { PhaseIndicator } from "@/components/retro/phase-indicator";
+import { HauntingPhase } from "@/components/retro/haunting-phase";
+import { WritingPhase } from "@/components/retro/writing-phase";
+import { GroupingPhase } from "@/components/retro/grouping-phase";
+import { VotingPhase } from "@/components/retro/voting-phase";
+import { DiscussActPhase } from "@/components/retro/discuss-act-phase";
+import { useRetroRoom } from "@/hooks/use-retro-room";
+import { getRetroStats, type RetroState, type CardGroup } from "@/lib/state-machines/retro";
+import { cn } from "@/lib/utils";
+import Link from "next/link";
+import { NavArrowLeft, LogOut, Copy, Check, Download } from "iconoir-react";
+import { generateCSV, downloadCSV } from "@/lib/csv";
+
+export function RetroRoomClient({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id: roomId } = use(params);
+  const searchParams = useSearchParams();
+  const teamId = searchParams.get("team") ?? undefined;
+  const [playerName, setPlayerName] = useState("");
+  const [joined, setJoined] = useState(false);
+
+  if (!joined) {
+    return (
+      <JoinScreen
+        name={playerName}
+        onNameChange={setPlayerName}
+        onJoin={() => setJoined(true)}
+      />
+    );
+  }
+
+  return (
+    <RetroRoom
+      roomId={roomId}
+      teamId={teamId}
+      playerName={playerName}
+      onLeave={() => {
+        setJoined(false);
+        setPlayerName("");
+      }}
+    />
+  );
+}
+
+// ── Join Screen ──
+
+function JoinScreen({
+  name,
+  onNameChange,
+  onJoin,
+}: {
+  name: string;
+  onNameChange: (name: string) => void;
+  onJoin: () => void;
+}) {
+  return (
+    <div className="flex min-h-svh flex-col px-4">
+      <div className="px-2 py-5 sm:px-8">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 text-sm font-bold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+        >
+          <NavArrowLeft width={16} height={16} />
+          Back
+        </Link>
+      </div>
+
+      <div className="stagger-in mx-auto flex flex-1 w-full max-w-sm flex-col items-center justify-center space-y-8 text-center">
+        <div className="mx-auto flex h-24 w-24 items-center justify-center rounded-md border-2 border-coffee/40 bg-coffee/10 text-coffee shadow-hard">
+          <GhostIcon size={52} />
+        </div>
+
+        <div>
+          <h1 className="font-display text-4xl tracking-ceremony sm:text-5xl">
+            Retro
+          </h1>
+          <p className="mt-2 text-sm font-medium text-muted-foreground">
+            Enter your name to join the room.
+          </p>
+        </div>
+
+        <div className="space-y-3">
+          <Input
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            placeholder="Your name"
+            onKeyDown={(e) => e.key === "Enter" && name.trim() && onJoin()}
+            autoFocus
+            className="h-12 border-2 border-border bg-card text-center font-bold shadow-hard placeholder:text-muted-foreground/50 focus:border-coffee"
+          />
+          <Button
+            onClick={onJoin}
+            disabled={!name.trim()}
+            className="h-12 w-full"
+            size="lg"
+          >
+            Join retro
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Retro Room ──
+
+function RetroRoom({
+  roomId,
+  teamId,
+  playerName,
+  onLeave,
+}: {
+  roomId: string;
+  teamId?: string;
+  playerName: string;
+  onLeave: () => void;
+}) {
+  const { userId: clerkUserId } = useAuth();
+
+  const {
+    state,
+    myId,
+    myAnonymousId,
+    isFacilitator,
+    connected,
+    startRetro,
+    markAction,
+    advancePhase,
+    addCard,
+    editCard,
+    removeCard,
+    moveCardPosition,
+    scatterCards,
+    sendCursor,
+    cursors,
+    createGroup,
+    renameGroup,
+    moveCardToGroup,
+    removeCardFromGroup,
+    castVote,
+    removeVote,
+    myVoteCount,
+    setTimer,
+    toggleTimer,
+    nextTopic,
+    addActionItem,
+    removeActionItem,
+    updateActionItem,
+    closeRetro,
+    typingOthers,
+    startTyping,
+    stopTyping,
+  } = useRetroRoom({ roomId, playerName, clerkUserId });
+
+  // Unresolved items from previous retro (groups without action items)
+  const [unresolvedItems, setUnresolvedItems] = useState<ReadonlyArray<{ id: string; label: string; category?: string; voteCount?: number }>>([]);
+
+  const myVotesByGroup = useMemo(() => {
+    if (!state || !myId) return new Map<string, number>();
+    const map = new Map<string, number>();
+    for (const vote of state.votes) {
+      if (vote.odiedId === myId) {
+        map.set(vote.groupId, (map.get(vote.groupId) ?? 0) + 1);
+      }
+    }
+    return map;
+  }, [state, myId]);
+
+  // Loading state
+  if (!state) {
+    return (
+      <div className="mx-auto flex min-h-svh max-w-3xl flex-col px-4 py-8">
+        <ConnectionStatus connected={connected} hasState={false} />
+        {connected && (
+          <>
+            <Skeleton className="h-8 w-48" />
+            <Skeleton className="mt-4 h-4 w-32" />
+            <div className="mt-12 space-y-4">
+              <Skeleton className="h-20 w-full" />
+              <Skeleton className="h-20 w-full" />
+            </div>
+          </>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto flex min-h-svh max-w-4xl flex-col px-4 py-6 sm:py-8">
+      <ConnectionStatus connected={connected} hasState={!!state} />
+      {/* Header */}
+      <header className="flex items-center justify-between">
+        <div>
+          <div className="flex items-baseline gap-3">
+            <Link
+              href="/"
+              className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border-2 border-border bg-card text-muted-foreground shadow-hard-sm transition-colors hover:border-foreground/40 hover:text-foreground"
+              aria-label="Back to home"
+            >
+              <NavArrowLeft width={16} height={16} />
+            </Link>
+            <h1 className="font-display text-3xl tracking-ceremony sm:text-4xl">
+              Retro
+            </h1>
+          </div>
+          <div className="mt-1 flex items-center gap-2">
+            <span className="text-xs font-bold text-muted-foreground">
+              {state.participants.length} participant
+              {state.participants.length !== 1 ? "s" : ""}
+            </span>
+            <span
+              className={cn(
+                "inline-block h-2 w-2 rounded-full",
+                connected ? "bg-success" : "bg-destructive animate-pulse"
+              )}
+            />
+            {isFacilitator && (
+              <span className="rounded-md bg-coffee/10 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-coffee">
+                Facilitator
+              </span>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          {state.phase !== "lobby" && state.phase !== "closed" && (
+            <div className="hidden sm:block">
+              <PhaseIndicator phase={state.phase} />
+            </div>
+          )}
+          <button
+            onClick={onLeave}
+            className="inline-flex items-center gap-1.5 text-xs font-bold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+          >
+            <LogOut width={14} height={14} />
+            Leave
+          </button>
+          <ThemeToggle />
+        </div>
+      </header>
+
+      {/* Mobile phase indicator */}
+      {state.phase !== "lobby" && state.phase !== "closed" && (
+        <div className="mt-3 overflow-x-auto sm:hidden">
+          <PhaseIndicator phase={state.phase} />
+        </div>
+      )}
+
+      {/* Divider */}
+      <div className="my-5 h-0.5 bg-border" />
+
+      {/* Phase content */}
+      <div className="flex-1">
+        {state.phase === "lobby" && (
+          <LobbyPhase
+            teamId={teamId}
+            isFacilitator={isFacilitator}
+            participantCount={state.participants.length}
+            participants={state.participants}
+            onStart={startRetro}
+            onUnresolvedItems={setUnresolvedItems}
+          />
+        )}
+
+        {state.phase === "haunting" && (
+          <HauntingPhase
+            actions={state.previousActions}
+            unresolvedItems={unresolvedItems}
+            isFacilitator={isFacilitator}
+            onMark={markAction}
+            onAdvance={advancePhase}
+          />
+        )}
+
+        {state.phase === "writing" && (
+          <WritingPhase
+            cards={state.cards}
+            myAnonymousId={myAnonymousId}
+            onAddCard={addCard}
+            onEditCard={editCard}
+            onRemoveCard={removeCard}
+            isFacilitator={isFacilitator}
+            onAdvance={advancePhase}
+            participantCount={state.participants.length}
+            typingOthers={typingOthers}
+            onStartTyping={startTyping}
+            onStopTyping={stopTyping}
+          />
+        )}
+
+        {state.phase === "grouping" && (
+          <GroupingPhase
+            cards={state.cards}
+            groups={state.groups}
+            cardPositions={state.cardPositions}
+            cursors={cursors}
+            myId={myId}
+            isFacilitator={isFacilitator}
+            onMoveCard={moveCardPosition}
+            onScatterCards={scatterCards}
+            onSendCursor={sendCursor}
+            onRenameGroup={renameGroup}
+            onAdvance={advancePhase}
+          />
+        )}
+
+        {state.phase === "voting" && (
+          <VotingPhase
+            groups={state.groups}
+            cards={state.cards}
+            participants={state.participants}
+            votes={state.votes}
+            myVoteCount={myVoteCount}
+            maxVotes={state.maxVotesPerPerson}
+            myVotesByGroup={myVotesByGroup}
+            isFacilitator={isFacilitator}
+            onVote={castVote}
+            onRemoveVote={removeVote}
+            onAdvance={advancePhase}
+          />
+        )}
+
+        {(state.phase === "discussing" || state.phase === "committing") && (
+          <DiscussActPhase
+            groups={state.groups}
+            cards={state.cards}
+            rankedGroupIds={state.rankedGroupIds}
+            actionItems={state.actionItems}
+            participants={state.participants}
+            isFacilitator={isFacilitator}
+            onAddItem={(text, assignees, groupId) =>
+              addActionItem(text, assignees, groupId)
+            }
+            onRemoveItem={removeActionItem}
+            onClose={closeRetro}
+          />
+        )}
+
+        {state.phase === "closed" && (
+          <ClosedPhase state={state} onDone={onLeave} />
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Lobby Phase ──
+
+function LobbyPhase({
+  teamId,
+  isFacilitator,
+  participantCount,
+  participants,
+  onStart,
+  onUnresolvedItems,
+}: {
+  teamId?: string;
+  isFacilitator: boolean;
+  participantCount: number;
+  participants: ReadonlyArray<{ id: string; name: string }>;
+  onStart: (options?: { teamId?: string; createdBy?: string; previousActions?: ReadonlyArray<import("@/lib/state-machines/retro").PreviousAction> }) => void;
+  onUnresolvedItems: (items: ReadonlyArray<{ id: string; label: string; category?: string; voteCount?: number }>) => void;
+}) {
+  const { user } = useUser();
+  const [previousActions, setPreviousActions] = useState<ReadonlyArray<import("@/lib/state-machines/retro").PreviousAction>>([]);
+  const [loadingActions, setLoadingActions] = useState(false);
+  const [loaded, setLoaded] = useState(false);
+
+  // Fetch previous retro data when facilitator joins (requires a real team ID)
+  useEffect(() => {
+    if (!isFacilitator || !teamId || loaded) return;
+    setLoadingActions(true);
+    fetch(`/api/retros/previous-actions?teamId=${teamId}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.actions?.length > 0) {
+          setPreviousActions(
+            data.actions.map((a: { id: string; text: string; assignees: string[]; done: boolean }) => ({
+              id: a.id,
+              text: a.text,
+              assignees: a.assignees ?? [],
+              done: a.done,
+            }))
+          );
+        }
+        // Collect unresolved items: groups without action items
+        const unresolved: Array<{ id: string; label: string; category?: string; voteCount?: number }> = [];
+        if (data.groups?.length > 0) {
+          for (const g of data.groups as Array<{ id: string; label: string; voteCount: number; hasActions: boolean }>) {
+            if (!g.hasActions) {
+              unresolved.push({ id: g.id, label: g.label, voteCount: g.voteCount });
+            }
+          }
+        }
+        onUnresolvedItems(unresolved);
+      })
+      .catch(() => {}) // DB might not be set up yet, that's OK
+      .finally(() => {
+        setLoadingActions(false);
+        setLoaded(true);
+      });
+  }, [isFacilitator, teamId, loaded, onUnresolvedItems]);
+
+  const handleStart = () => {
+    onStart({
+      teamId,
+      createdBy: user?.id,
+      previousActions: previousActions.length > 0 ? previousActions : undefined,
+    });
+  };
+
+  return (
+    <div className="stagger-in mx-auto max-w-md space-y-6 text-center">
+      <div className="flex justify-center text-coffee">
+        <GhostIcon size={64} />
+      </div>
+      <div>
+        <h2 className="font-display text-3xl tracking-ceremony">
+          Ready for retro?
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          {participantCount} participant{participantCount !== 1 ? "s" : ""}{" "}
+          in the room
+        </p>
+      </div>
+
+      {/* Participant list */}
+      <div className="flex flex-wrap justify-center gap-2">
+        {participants.map((p) => (
+          <span
+            key={p.id}
+            className="rounded-md border-2 border-border bg-card px-3 py-1.5 text-xs font-bold shadow-hard-sm"
+          >
+            {p.name}
+          </span>
+        ))}
+      </div>
+
+      {/* Previous actions preview */}
+      {previousActions.length > 0 && (
+        <div className="rounded-md border-2 border-coffee/30 bg-coffee/5 p-3 text-left">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-coffee mb-2">
+            <GhostIcon size={12} className="inline mr-1" />
+            {previousActions.length} action item{previousActions.length !== 1 ? "s" : ""} from last retro
+          </p>
+          {previousActions.slice(0, 3).map((a) => (
+            <p key={a.id} className="text-xs text-muted-foreground truncate">
+              {a.done ? "Done" : "Pending"}: {a.text}
+            </p>
+          ))}
+          {previousActions.length > 3 && (
+            <p className="text-xs text-muted-foreground">
+              +{previousActions.length - 3} more...
+            </p>
+          )}
+        </div>
+      )}
+
+      {isFacilitator ? (
+        <Button
+          onClick={handleStart}
+          disabled={loadingActions}
+          className="h-12"
+          size="lg"
+        >
+          {loadingActions ? "Loading previous actions..." : "Start retro"}
+        </Button>
+      ) : (
+        <p className="text-xs font-bold text-muted-foreground">
+          Waiting for facilitator to start...
+        </p>
+      )}
+    </div>
+  );
+}
+
+// ── Closed Phase ──
+
+function ClosedPhase({
+  state,
+  onDone,
+}: {
+  state: RetroState;
+  onDone: () => void;
+}) {
+  const [copied, setCopied] = useState(false);
+  const stats = getRetroStats(state);
+
+  // Build summary text grouped by topic
+  const rankedGroups = state.rankedGroupIds
+    .map((id) => state.groups.find((g) => g.id === id))
+    .filter(Boolean) as ReadonlyArray<CardGroup>;
+  const allGroups = [
+    ...rankedGroups,
+    ...state.groups.filter((g) => !state.rankedGroupIds.includes(g.id)),
+  ];
+
+  const summaryLines: string[] = [
+    "Retro Summary",
+    "=".repeat(40),
+    `Cards: ${stats.totalCards} | Groups: ${stats.groupCount} | Actions: ${stats.actionCount}`,
+    "",
+  ];
+  for (const group of allGroups) {
+    const actions = state.actionItems.filter((a) => a.groupId === group.id);
+    summaryLines.push(`## ${group.label} (${group.voteCount} votes)`);
+    for (const a of actions) {
+      summaryLines.push(`  - [ ] ${a.text}${a.assignees.length > 0 ? ` (${a.assignees.join(", ")})` : ""}`);
+    }
+    summaryLines.push("");
+  }
+  const generalActions = state.actionItems.filter((a) => !a.groupId);
+  if (generalActions.length > 0) {
+    summaryLines.push("## General");
+    for (const a of generalActions) {
+      summaryLines.push(`  - [ ] ${a.text}${a.assignees.length > 0 ? ` (${a.assignees.join(", ")})` : ""}`);
+    }
+  }
+  const summaryText = summaryLines.join("\n");
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(summaryText).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    });
+  }, [summaryText]);
+
+  const handleDownloadCSV = useCallback(() => {
+    const csv = generateCSV(
+      ["Action Item", "Assignees", "Topic", "Votes"],
+      state.actionItems.map((item) => {
+        const group = state.groups.find((g) => g.id === item.groupId);
+        return [
+          item.text,
+          item.assignees.join("; "),
+          group?.label ?? "General",
+          String(group?.voteCount ?? 0),
+        ];
+      })
+    );
+    downloadCSV(csv, `retro-actions-${new Date().toISOString().slice(0, 10)}.csv`);
+  }, [state]);
+
+  return (
+    <div className="stagger-in mx-auto max-w-2xl space-y-6">
+      {/* Header */}
+      <div className="text-center">
+        <GhostIcon size={64} className="mx-auto text-coffee" />
+        <h2 className="mt-4 font-display text-3xl tracking-ceremony sm:text-4xl">
+          Retro complete
+        </h2>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Great session. Here's your snapshot.
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="flex justify-center gap-4">
+        <StatBox value={stats.totalCards} label="cards" />
+        <StatBox value={stats.groupCount} label="groups" />
+        <StatBox value={stats.actionCount} label="actions" />
+      </div>
+
+      {/* Snapshot: Topics + Action Items */}
+      {allGroups.map((group, i) => {
+        const actions = state.actionItems.filter((a) => a.groupId === group.id);
+        if (group.voteCount === 0 && actions.length === 0) return null;
+        return (
+          <div key={group.id} className="rounded-md border-2 border-border bg-card p-4 shadow-hard-sm">
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span className="flex h-6 w-6 items-center justify-center rounded-md bg-primary/15 font-mono text-[10px] font-bold text-primary">
+                  {i + 1}
+                </span>
+                <h3 className="text-sm font-bold">{group.label}</h3>
+              </div>
+              <span className="font-mono text-xs text-muted-foreground">
+                {group.voteCount} vote{group.voteCount !== 1 ? "s" : ""}
+              </span>
+            </div>
+            {actions.length > 0 && (
+              <div className="mt-3 space-y-1.5">
+                {actions.map((item) => (
+                  <div key={item.id} className="flex items-start gap-2 text-sm">
+                    <GhostIcon size={14} className="mt-0.5 shrink-0 text-coffee" />
+                    <div>
+                      <span className="font-medium">{item.text}</span>
+                      {item.assignees.length > 0 && (
+                        <span className="ml-1.5 text-xs text-muted-foreground">
+                          ({item.assignees.join(", ")})
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      {/* General actions */}
+      {generalActions.length > 0 && (
+        <div className="rounded-md border-2 border-dashed border-border bg-muted/20 p-4">
+          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground mb-2">
+            General action items
+          </p>
+          {generalActions.map((item) => (
+            <div key={item.id} className="flex items-start gap-2 text-sm mb-1.5">
+              <GhostIcon size={14} className="mt-0.5 shrink-0 text-coffee" />
+              <span className="font-medium">{item.text}</span>
+              {item.assignees.length > 0 && (
+                <span className="text-xs text-muted-foreground">
+                  ({item.assignees.join(", ")})
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-col gap-3 pt-2">
+        <div className="grid grid-cols-2 gap-3">
+          <Button onClick={handleCopy} variant="outline">
+            {copied ? (
+              <><Check width={16} height={16} /> Copied!</>
+            ) : (
+              <><Copy width={16} height={16} /> Copy summary</>
+            )}
+          </Button>
+          {state.actionItems.length > 0 && (
+            <Button onClick={handleDownloadCSV} variant="outline">
+              <Download width={16} height={16} />
+              Export actions
+            </Button>
+          )}
+        </div>
+        <Button onClick={onDone} className="w-full">
+          Done
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function StatBox({ value, label }: { value: number; label: string }) {
+  return (
+    <div className="rounded-md bg-muted px-4 py-3 text-center">
+      <p className="font-mono text-2xl font-bold">{value}</p>
+      <p className="text-[10px] font-bold uppercase tracking-widest text-muted-foreground">
+        {label}
+      </p>
+    </div>
+  );
+}
+

--- a/src/app/(marketing)/pricing/page.tsx
+++ b/src/app/(marketing)/pricing/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+export const metadata = {
+  title: "Pricing | Ceremonies",
+  description: "Simple, transparent pricing for Ceremonies, the open-source agile ceremony toolkit.",
+};
+
+export default function PricingPage() {
+  redirect("/#pricing");
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -393,6 +393,24 @@
   animation: timer-pulse 2s var(--ease-ceremony) infinite;
 }
 
+/* ── Typing indicator dot ── */
+
+@keyframes typing-pulse {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1); }
+}
+
+.typing-dot {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background-color: currentColor;
+  animation: typing-pulse 1.2s ease-in-out infinite;
+  color: var(--muted-foreground);
+  opacity: 0.7;
+}
+
 /* ── Reduced motion ── */
 
 @media (prefers-reduced-motion: reduce) {
@@ -422,6 +440,10 @@
   }
   .timer-pulse {
     animation: none;
+  }
+  .typing-dot {
+    animation: none;
+    opacity: 0.5;
   }
   [class*="animate-[drift"] {
     animation: none !important;

--- a/src/components/retro/closed-retro-summary.tsx
+++ b/src/components/retro/closed-retro-summary.tsx
@@ -1,0 +1,219 @@
+import Link from "next/link";
+import { GhostIcon, HappyIcon, SadIcon, ConfusedIcon } from "@/components/shared/icons";
+import { cn } from "@/lib/utils";
+import { NavArrowLeft } from "iconoir-react";
+
+// ── Types ──
+
+type CardCategory = "happy" | "sad" | "confused";
+
+interface SummaryCard {
+  id: string;
+  text: string;
+  category: CardCategory;
+}
+
+interface SummaryActionItem {
+  id: string;
+  text: string;
+  assignees: string[];
+  groupId: string | null;
+}
+
+interface SummaryGroup {
+  id: string;
+  label: string;
+  voteCount: number;
+  rank: number | null;
+  cards: SummaryCard[];
+  actionItems: SummaryActionItem[];
+}
+
+export interface ClosedRetroSummaryProps {
+  roomCode: string;
+  closedAt: Date | null;
+  groups: SummaryGroup[];
+  generalActionItems: SummaryActionItem[];
+}
+
+// ── Icon + color maps ──
+
+const CATEGORY_ICON: Record<CardCategory, React.ComponentType<{ size?: number; className?: string }>> = {
+  happy: HappyIcon,
+  sad: SadIcon,
+  confused: ConfusedIcon,
+};
+
+const CATEGORY_COLOR: Record<CardCategory, string> = {
+  happy: "text-happy",
+  sad: "text-sad",
+  confused: "text-confused",
+};
+
+// ── Main component ──
+
+export function ClosedRetroSummary({
+  roomCode,
+  closedAt,
+  groups,
+  generalActionItems,
+}: ClosedRetroSummaryProps) {
+  const closedDateString = closedAt
+    ? closedAt.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric",
+        year: "numeric",
+      })
+    : null;
+
+  const rankedGroups = [...groups].sort((a, b) => {
+    if (a.rank !== null && b.rank !== null) return a.rank - b.rank;
+    if (a.rank !== null) return -1;
+    if (b.rank !== null) return 1;
+    return b.voteCount - a.voteCount;
+  });
+
+  return (
+    <div className="mx-auto min-h-svh max-w-3xl px-4 py-6 sm:py-8">
+      {/* Back link */}
+      <div className="mb-6">
+        <Link
+          href="/dashboard"
+          className="inline-flex items-center gap-1.5 text-sm font-bold text-muted-foreground underline underline-offset-4 transition-colors hover:text-foreground"
+        >
+          <NavArrowLeft width={16} height={16} />
+          Back to dashboard
+        </Link>
+      </div>
+
+      {/* Header */}
+      <header className="mb-6">
+        <div className="flex items-baseline gap-3">
+          <GhostIcon size={32} className="text-coffee shrink-0" />
+          <div>
+            <h1 className="font-display text-3xl tracking-ceremony sm:text-4xl">
+              Retro {roomCode}
+            </h1>
+            <p className="mt-1 text-xs font-bold text-muted-foreground">
+              {closedDateString ? `Closed ${closedDateString}` : "Closed"}
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-4 inline-flex items-center gap-2 rounded-md border-2 border-border bg-muted/40 px-3 py-1.5">
+          <span className="h-2 w-2 rounded-full bg-muted-foreground/40" />
+          <span className="text-xs font-bold text-muted-foreground">
+            This retro is closed. These action items will haunt your next retro.
+          </span>
+        </div>
+      </header>
+
+      <div className="h-0.5 bg-border mb-8" />
+
+      {/* Groups */}
+      <div className="space-y-6">
+        {rankedGroups.map((group, i) => (
+          <GroupCard key={group.id} group={group} rank={i + 1} />
+        ))}
+      </div>
+
+      {/* General action items */}
+      {generalActionItems.length > 0 && (
+        <div className="mt-6 rounded-md border-2 border-dashed border-border bg-muted/20 p-5">
+          <div className="flex items-center gap-2 mb-3">
+            <GhostIcon size={16} className="text-coffee" />
+            <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+              General action items
+            </span>
+          </div>
+          {generalActionItems.map((item) => (
+            <ActionItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Group card ──
+
+function GroupCard({ group, rank }: { group: SummaryGroup; rank: number }) {
+  const hasContent = group.cards.length > 0 || group.actionItems.length > 0;
+  if (!hasContent && group.voteCount === 0) return null;
+
+  return (
+    <div className="rounded-md border-2 border-border bg-card shadow-hard overflow-hidden">
+      {/* Group header */}
+      <div className="flex items-center justify-between border-b-2 border-border bg-muted/30 px-5 py-3">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
+            {rank}
+          </span>
+          <h3 className="min-w-0 break-words font-display text-lg tracking-ceremony">
+            {group.label}
+          </h3>
+        </div>
+        <span className="rounded-md bg-primary/10 px-2.5 py-1 font-mono text-xs font-bold text-primary">
+          {group.voteCount} vote{group.voteCount !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      {/* Cards */}
+      {group.cards.length > 0 && (
+        <div className="px-5 py-4 space-y-2">
+          {group.cards.map((card) => {
+            const Icon = CATEGORY_ICON[card.category];
+            return (
+              <div
+                key={card.id}
+                className="flex items-start gap-2 rounded-md border border-border bg-background p-3 text-sm"
+              >
+                <Icon
+                  size={18}
+                  className={cn("mt-0.5 shrink-0", CATEGORY_COLOR[card.category])}
+                />
+                <span>{card.text}</span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Action items */}
+      {group.actionItems.length > 0 && (
+        <div className={cn("border-t-2 border-dashed border-border bg-muted/20 px-5 py-4", group.cards.length === 0 && "border-t-0")}>
+          <div className="flex items-center gap-2 mb-3">
+            <GhostIcon size={16} className="text-coffee" />
+            <span className="text-[10px] font-bold uppercase tracking-[0.12em] text-muted-foreground">
+              Action items
+            </span>
+            <span className="rounded-md bg-coffee/10 px-1.5 py-0.5 font-mono text-[9px] font-bold text-coffee">
+              {group.actionItems.length}
+            </span>
+          </div>
+          {group.actionItems.map((item) => (
+            <ActionItemRow key={item.id} item={item} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── Action item row ──
+
+function ActionItemRow({ item }: { item: SummaryActionItem }) {
+  return (
+    <div className="flex items-start gap-2 text-sm mb-2 last:mb-0">
+      <GhostIcon size={14} className="mt-0.5 shrink-0 text-coffee" />
+      <div>
+        <span className="font-medium">{item.text}</span>
+        {item.assignees.length > 0 && (
+          <span className="ml-1.5 text-xs text-muted-foreground">
+            ({item.assignees.join(", ")})
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/retro/discuss-act-phase.tsx
+++ b/src/components/retro/discuss-act-phase.tsx
@@ -157,11 +157,11 @@ function TopicSection({
     >
       {/* Topic header */}
       <div className="flex items-center justify-between border-b-2 border-border bg-muted/30 px-5 py-3">
-        <div className="flex items-center gap-3">
-          <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
+        <div className="flex min-w-0 items-center gap-3">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-primary/15 font-mono text-xs font-bold text-primary">
             {rank}
           </span>
-          <h3 className="font-display text-lg tracking-ceremony">
+          <h3 className="min-w-0 break-words font-display text-lg tracking-ceremony">
             {group.label}
           </h3>
         </div>

--- a/src/components/retro/grouping-phase.tsx
+++ b/src/components/retro/grouping-phase.tsx
@@ -280,16 +280,70 @@ export function GroupingPhase({
             {groups.length} group{groups.length !== 1 ? "s" : ""} formed:
           </span>
           {groups.map((g) => (
-            <span
+            <RenameableChip
               key={g.id}
-              className="rounded-md border-2 border-border bg-muted px-2.5 py-1 text-xs font-bold"
-            >
-              {g.label} ({g.cardIds.length})
-            </span>
+              group={g}
+              onRename={onRenameGroup}
+            />
           ))}
         </div>
       )}
     </div>
+  );
+}
+
+/** Inline-editable chip for renaming a group from the summary row. */
+function RenameableChip({
+  group,
+  onRename,
+}: {
+  group: CardGroup;
+  onRename: (groupId: string, label: string) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [label, setLabel] = useState(group.label);
+
+  // Sync when an external rename (e.g. canvas boundary) changes the label.
+  useEffect(() => {
+    if (!editing) setLabel(group.label);
+  }, [group.label, editing]);
+
+  const handleSave = () => {
+    const trimmed = label.trim();
+    if (trimmed && trimmed !== group.label) {
+      onRename(group.id, trimmed);
+    } else {
+      setLabel(group.label);
+    }
+    setEditing(false);
+  };
+
+  if (editing) {
+    return (
+      <input
+        value={label}
+        onChange={(e) => setLabel(e.target.value)}
+        onBlur={handleSave}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") handleSave();
+          if (e.key === "Escape") { setLabel(group.label); setEditing(false); }
+        }}
+        autoFocus
+        className="h-7 rounded-md border-2 border-primary bg-card px-2 text-xs font-bold focus:outline-none"
+        style={{ minWidth: "6rem" }}
+      />
+    );
+  }
+
+  return (
+    <button
+      onClick={() => setEditing(true)}
+      className="flex items-center gap-1 rounded-md border-2 border-border bg-muted px-2.5 py-1 text-xs font-bold transition-colors hover:border-primary hover:bg-primary/10"
+      title="Click to rename group"
+    >
+      {group.label} ({group.cardIds.length})
+      <EditPencil width={10} height={10} className="shrink-0 text-muted-foreground" />
+    </button>
   );
 }
 

--- a/src/components/retro/grouping-phase.tsx
+++ b/src/components/retro/grouping-phase.tsx
@@ -238,7 +238,7 @@ export function GroupingPhase({
               onPointerDown={(e) => handlePointerDown(card.id, e)}
             >
               <Icon size={20} className={cn("shrink-0 mt-0.5", style.color)} />
-              <span className="line-clamp-4 leading-snug">{card.text}</span>
+              <span className="leading-snug">{card.text}</span>
             </div>
           );
         })}

--- a/src/components/retro/voting-phase.tsx
+++ b/src/components/retro/voting-phase.tsx
@@ -148,6 +148,15 @@ export function VotingPhase({
             Results revealed! Groups are now sorted by votes.
           </p>
         )}
+
+        {/* Facilitator advance button lives here so it is visible without scrolling */}
+        {isFacilitator && allVotesIn && (
+          <div className="mt-3 flex justify-center consensus-enter">
+            <Button onClick={onAdvance} className="h-11">
+              Start discussion
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Groups to vote on */}
@@ -260,15 +269,6 @@ export function VotingPhase({
           );
         })}
       </div>
-
-      {/* Facilitator advance: only after all votes are revealed */}
-      {isFacilitator && allVotesIn && (
-        <div className="text-center pt-2 consensus-enter">
-          <Button onClick={onAdvance} className="h-11">
-            Start discussion
-          </Button>
-        </div>
-      )}
 
       {isFacilitator && !allVotesIn && (
         <div className="space-y-1.5 text-center pt-2">

--- a/src/components/retro/writing-phase.tsx
+++ b/src/components/retro/writing-phase.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import type { RetroCard, CardCategory } from "@/lib/state-machines/retro";
 import { Button } from "@/components/ui/button";
 import { HappyIcon, SadIcon, ConfusedIcon } from "@/components/shared/icons";
@@ -16,6 +16,10 @@ interface WritingPhaseProps {
   readonly isFacilitator: boolean;
   readonly onAdvance: () => void;
   readonly participantCount: number;
+  /** How many other participants are currently typing (excludes self). */
+  readonly typingOthers: number;
+  readonly onStartTyping: () => void;
+  readonly onStopTyping: () => void;
 }
 
 const CATEGORIES: ReadonlyArray<{
@@ -61,15 +65,41 @@ export function WritingPhase({
   isFacilitator,
   onAdvance,
   participantCount,
+  typingOthers,
+  onStartTyping,
+  onStopTyping,
 }: WritingPhaseProps) {
   const [activeCategory, setActiveCategory] = useState<CardCategory>("happy");
   const [text, setText] = useState("");
   const [editingCardId, setEditingCardId] = useState<string | null>(null);
   const [editText, setEditText] = useState("");
 
+  // Debounce ref for the typing stop timeout.
+  const stopTypingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Clean up the typing indicator when the component unmounts (e.g. phase changes).
+  useEffect(() => {
+    return () => {
+      if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+      onStopTyping();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const handleTextChange = (value: string) => {
+    setText(value);
+    onStartTyping();
+    if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+    stopTypingTimer.current = setTimeout(() => {
+      onStopTyping();
+    }, 3000);
+  };
+
   const handleSubmit = () => {
     const trimmed = text.trim();
     if (!trimmed) return;
+    if (stopTypingTimer.current) clearTimeout(stopTypingTimer.current);
+    onStopTyping();
     onAddCard(activeCategory, trimmed);
     setText("");
   };
@@ -120,7 +150,7 @@ export function WritingPhase({
       <div className="space-y-3">
         <textarea
           value={text}
-          onChange={(e) => setText(e.target.value)}
+          onChange={(e) => handleTextChange(e.target.value)}
           placeholder={`What made you ${activeCategory}?`}
           onKeyDown={(e) => {
             if (e.key === "Enter" && !e.shiftKey) {
@@ -135,7 +165,19 @@ export function WritingPhase({
             `focus:${activeCat.borderClass}`
           )}
         />
-        <div className="flex justify-end">
+
+        {/* Anonymous typing indicator: shows when others are typing. Never shows names. */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-1.5 h-4">
+            {typingOthers > 0 && (
+              <>
+                <span className="typing-dot" />
+                <span className="text-[11px] font-medium text-muted-foreground opacity-70">
+                  Someone is typing...
+                </span>
+              </>
+            )}
+          </div>
           <Button
             onClick={handleSubmit}
             disabled={!text.trim()}

--- a/src/hooks/use-retro-room.ts
+++ b/src/hooks/use-retro-room.ts
@@ -25,6 +25,13 @@ interface UseRetroRoomResult {
   readonly isFacilitator: boolean;
   readonly connected: boolean;
 
+  /** Number of other participants currently typing (excludes self). */
+  readonly typingOthers: number;
+  /** Notify the server that this participant started typing. */
+  readonly startTyping: () => void;
+  /** Notify the server that this participant stopped typing. */
+  readonly stopTyping: () => void;
+
   // Lobby
   readonly startRetro: (options?: { teamId?: string; createdBy?: string; previousActions?: ReadonlyArray<PreviousAction> }) => void;
 
@@ -82,6 +89,7 @@ export function useRetroRoom({
   const [myAnonymousId, setMyAnonymousId] = useState<string | null>(null);
   const [connected, setConnected] = useState(false);
   const [cursors, setCursors] = useState<ReadonlyMap<string, CursorPosition>>(new Map());
+  const [typingParticipantIds, setTypingParticipantIds] = useState<ReadonlyArray<string>>([]);
   const stateRef = useRef(state);
 
   useEffect(() => {
@@ -136,6 +144,8 @@ export function useRetroRoom({
           });
           return next;
         });
+      } else if (data.type === "typing_update") {
+        setTypingParticipantIds(data.participantIds as string[]);
       }
     },
   });
@@ -199,6 +209,14 @@ export function useRetroRoom({
     },
     [send, myAnonymousId]
   );
+
+  const startTyping = useCallback(() => {
+    send({ type: "TYPING_START" });
+  }, [send]);
+
+  const stopTyping = useCallback(() => {
+    send({ type: "TYPING_STOP" });
+  }, [send]);
 
   // ── Grouping (canvas) ──
 
@@ -334,12 +352,18 @@ export function useRetroRoom({
 
   const isFacilitator = Boolean(myId && state && state.facilitatorId === myId);
 
+  // Count participants typing, excluding self. Never includes names.
+  const typingOthers = typingParticipantIds.filter((id) => id !== myId).length;
+
   return {
     state,
     myId,
     myAnonymousId,
     isFacilitator,
     connected,
+    typingOthers,
+    startTyping,
+    stopTyping,
     startRetro,
     markAction,
     advancePhase,

--- a/src/lib/state-machines/retro.ts
+++ b/src/lib/state-machines/retro.ts
@@ -284,7 +284,7 @@ export function transition(state: RetroState, event: RetroEvent): RetroState {
         const ungrouped = state.cards.filter((c) => !groupedCardIds.has(c.id));
         const newGroups = ungrouped.map((c) => ({
           id: `auto-${c.id}`,
-          label: c.text.slice(0, 40),
+          label: c.text,
           cardIds: [c.id] as ReadonlyArray<string>,
           voteCount: 0,
         }));
@@ -647,9 +647,7 @@ export function computeProximityGroups(
   const groups: CardGroup[] = [];
   for (const [root, members] of clusters) {
     const firstCard = cards.find((c) => c.id === members[0]);
-    const label = firstCard
-      ? firstCard.text.slice(0, 30) + (firstCard.text.length > 30 ? "..." : "")
-      : "Group";
+    const label = firstCard ? firstCard.text : "Group";
     groups.push({
       id: `prox-${root}`,
       label,

--- a/tests/retro-closed-summary.mjs
+++ b/tests/retro-closed-summary.mjs
@@ -1,0 +1,258 @@
+/**
+ * Closed Retro Summary Tests
+ *
+ * Two test modes:
+ *
+ * 1. Unit tests (always run): validate the data-shape transform that maps
+ *    raw DB rows into ClosedRetroSummaryProps. No server or DB required.
+ *
+ * 2. Integration tests (optional, requires DATABASE_URL + running Next.js):
+ *    Seeds a fake closed retro, fetches the page HTML, asserts the
+ *    summary content appears and "Join retro" button does not.
+ *    Skipped automatically when DATABASE_URL or APP_HOST are missing.
+ *
+ * Usage:
+ *   node tests/retro-closed-summary.mjs
+ *   DATABASE_URL=<url> APP_HOST=http://localhost:3456 node tests/retro-closed-summary.mjs
+ */
+
+import { neon } from "@neondatabase/serverless";
+
+const APP_HOST = process.env.APP_HOST || "http://localhost:3456";
+const DATABASE_URL = process.env.DATABASE_URL;
+
+const log = (msg) =>
+  console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, label) {
+  if (condition) {
+    console.log(`  PASS: ${label}`);
+    passed++;
+  } else {
+    console.error(`  FAIL: ${label}`);
+    failed++;
+  }
+}
+
+// ── Data transform (mirrors the logic in page.tsx) ──
+
+function buildSummaryGroups(groups, cards, actions) {
+  return groups.map((g) => ({
+    id: g.id,
+    label: g.label,
+    voteCount: g.voteCount ?? 0,
+    rank: g.rank,
+    cards: cards
+      .filter((c) => c.groupId === g.id)
+      .map((c) => ({ id: c.id, text: c.text, category: c.category })),
+    actionItems: actions
+      .filter((a) => a.groupId === g.id)
+      .map((a) => ({
+        id: a.id,
+        text: a.text,
+        assignees: a.assignees ?? [],
+        groupId: a.groupId,
+      })),
+  }));
+}
+
+function buildGeneralActionItems(actions) {
+  return actions
+    .filter((a) => a.groupId === null)
+    .map((a) => ({
+      id: a.id,
+      text: a.text,
+      assignees: a.assignees ?? [],
+      groupId: null,
+    }));
+}
+
+// Sorts groups by rank (nulls last), then by voteCount desc
+function sortGroups(groups) {
+  return [...groups].sort((a, b) => {
+    if (a.rank !== null && b.rank !== null) return a.rank - b.rank;
+    if (a.rank !== null) return -1;
+    if (b.rank !== null) return 1;
+    return b.voteCount - a.voteCount;
+  });
+}
+
+// ── Unit tests ──
+
+function runUnitTests() {
+  console.log("\n=== Unit tests: data-shape transform ===\n");
+
+  const fakeGroups = [
+    { id: "g1", label: "Deployment speed", voteCount: 5, rank: 1 },
+    { id: "g2", label: "Code review lag", voteCount: 3, rank: 2 },
+    { id: "g3", label: "No rank group", voteCount: 1, rank: null },
+  ];
+
+  const fakeCards = [
+    { id: "c1", groupId: "g1", text: "Deploy takes 40 mins", category: "sad" },
+    { id: "c2", groupId: "g1", text: "Pipeline finally green", category: "happy" },
+    { id: "c3", groupId: "g2", text: "PRs sit for days", category: "confused" },
+  ];
+
+  const fakeActions = [
+    { id: "a1", retroId: "r1", groupId: "g1", text: "Set up faster CI", assignees: ["Alice"], done: false },
+    { id: "a2", retroId: "r1", groupId: "g2", text: "Agree 24h review SLA", assignees: [], done: false },
+    { id: "a3", retroId: "r1", groupId: null, text: "Book retro retrospective", assignees: ["Bob"], done: false },
+  ];
+
+  const summaryGroups = buildSummaryGroups(fakeGroups, fakeCards, fakeActions);
+  const generalItems = buildGeneralActionItems(fakeActions);
+  const sorted = sortGroups(summaryGroups);
+
+  assert(summaryGroups.length === 3, "builds 3 summary groups");
+
+  const g1 = summaryGroups.find((g) => g.id === "g1");
+  assert(g1 !== undefined, "g1 present in summary groups");
+  assert(g1?.cards.length === 2, "g1 has 2 cards");
+  assert(g1?.actionItems.length === 1, "g1 has 1 action item");
+  assert(g1?.actionItems[0]?.text === "Set up faster CI", "g1 action item text correct");
+  assert(g1?.actionItems[0]?.assignees[0] === "Alice", "g1 action item assignee correct");
+
+  const g2 = summaryGroups.find((g) => g.id === "g2");
+  assert(g2?.cards.length === 1, "g2 has 1 card");
+  assert(g2?.actionItems[0]?.assignees.length === 0, "g2 action item has empty assignees");
+
+  assert(generalItems.length === 1, "exactly 1 general action item");
+  assert(generalItems[0]?.text === "Book retro retrospective", "general action item text correct");
+  assert(generalItems[0]?.groupId === null, "general action item groupId is null");
+
+  // Sorting: ranked groups come first in rank order
+  assert(sorted[0]?.id === "g1", "rank-1 group sorts first");
+  assert(sorted[1]?.id === "g2", "rank-2 group sorts second");
+  assert(sorted[2]?.id === "g3", "unranked group sorts last");
+
+  // Null assignees fallback
+  const actionsWithNullAssignees = [
+    { id: "a4", retroId: "r1", groupId: null, text: "No assignees", assignees: null, done: false },
+  ];
+  const generalWithNull = buildGeneralActionItems(actionsWithNullAssignees);
+  assert(generalWithNull[0]?.assignees.length === 0, "null assignees defaults to empty array");
+
+  // A retro with no groups should produce no summary groups
+  const emptyGroupSummary = buildSummaryGroups([], fakeCards, fakeActions);
+  assert(emptyGroupSummary.length === 0, "empty groups input produces empty summary");
+
+  // Cards not in any group should not appear in group summaries
+  const ungroupedCard = { id: "c4", groupId: null, text: "Orphan card", category: "happy" };
+  const mixedCards = [...fakeCards, ungroupedCard];
+  const mixedSummary = buildSummaryGroups(fakeGroups, mixedCards, fakeActions);
+  const allCardsInGroups = mixedSummary.flatMap((g) => g.cards);
+  assert(
+    !allCardsInGroups.some((c) => c.id === "c4"),
+    "ungrouped cards do not appear in any group summary"
+  );
+}
+
+// ── Integration tests ──
+
+async function runIntegrationTests() {
+  console.log("\n=== Integration tests: page HTML assertions ===\n");
+
+  if (!DATABASE_URL) {
+    console.log("  SKIP: DATABASE_URL not set");
+    return;
+  }
+
+  const sql = neon(DATABASE_URL);
+  const roomCode = `test-${Math.random().toString(36).slice(2, 8)}`;
+
+  let retroId = null;
+  let groupId = null;
+
+  try {
+    // Seed: retro row
+    const [retroRow] = await sql`
+      INSERT INTO retros (room_code, status, created_by, closed_at, card_count, group_count, action_count)
+      VALUES (${roomCode}, 'closed', 'test-user', NOW(), 1, 1, 1)
+      RETURNING id
+    `;
+    retroId = retroRow.id;
+
+    // Seed: group
+    const [groupRow] = await sql`
+      INSERT INTO retro_groups (retro_id, label, vote_count, rank)
+      VALUES (${retroId}, 'Test group label', 4, 1)
+      RETURNING id
+    `;
+    groupId = groupRow.id;
+
+    // Seed: card
+    await sql`
+      INSERT INTO retro_cards (retro_id, category, text, anonymous_id, group_id)
+      VALUES (${retroId}, 'happy', 'Things went well', 'anon-1', ${groupId})
+    `;
+
+    // Seed: action item attached to group
+    await sql`
+      INSERT INTO action_items (retro_id, group_id, text, assignees, done)
+      VALUES (${retroId}, ${groupId}, 'Follow up on deployment', '["Charlie"]', false)
+    `;
+
+    // Seed: general action item
+    await sql`
+      INSERT INTO action_items (retro_id, group_id, text, assignees, done)
+      VALUES (${retroId}, NULL, 'General retro action', '[]', false)
+    `;
+
+    log(`Seeded closed retro room_code=${roomCode} retro_id=${retroId}`);
+
+    // Fetch the page HTML
+    const url = `${APP_HOST}/retro/${roomCode}`;
+    log(`Fetching ${url}`);
+    const res = await fetch(url);
+    const html = await res.text();
+
+    assert(res.ok, `page responds 200 (got ${res.status})`);
+    assert(html.includes("Test group label"), "group label appears in HTML");
+    assert(html.includes("Things went well"), "card text appears in HTML");
+    assert(html.includes("Follow up on deployment"), "action item text appears in HTML");
+    assert(html.includes("General retro action"), "general action item appears in HTML");
+    assert(!html.includes("Join retro"), '"Join retro" button absent in closed summary');
+    assert(html.includes(roomCode), "room code appears in HTML");
+  } finally {
+    // Cleanup
+    if (retroId) {
+      try {
+        await sql`DELETE FROM action_items WHERE retro_id = ${retroId}`;
+        await sql`DELETE FROM retro_cards WHERE retro_id = ${retroId}`;
+        await sql`DELETE FROM retro_groups WHERE retro_id = ${retroId}`;
+        await sql`DELETE FROM retros WHERE id = ${retroId}`;
+        log(`Cleaned up retro_id=${retroId}`);
+      } catch (cleanupErr) {
+        console.error("Cleanup failed:", cleanupErr);
+      }
+    }
+  }
+}
+
+// ── Main ──
+
+async function main() {
+  runUnitTests();
+
+  try {
+    await runIntegrationTests();
+  } catch (err) {
+    console.error("Integration test error:", err);
+    failed++;
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed\n`);
+
+  if (failed > 0) {
+    process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error("Unexpected error:", err);
+  process.exit(1);
+});

--- a/tests/retro-facilitator-promotion.mjs
+++ b/tests/retro-facilitator-promotion.mjs
@@ -8,8 +8,10 @@
  *   1. Anonymous participant A joins first and becomes facilitator (fallback).
  *   2. Creator participant B joins with userId matching state.createdBy.
  *      Facilitator should transfer to B.
- *   3. B disconnects. Facilitator should fall back to A.
- *   4. B reconnects. Facilitator should transfer back to B (creator reclaims).
+ *   3. B (creator) disconnects. Facilitator should STAY as B's participantId,
+ *      NOT fall back to A. The role is sticky to the creator.
+ *   4. B reconnects. Facilitator should transfer to B2's new participantId
+ *      (creator reclaims on join, no double-assignment).
  *
  * Usage: node tests/retro-facilitator-promotion.mjs [host] [roomId]
  *
@@ -149,26 +151,35 @@ async function run() {
     "A's broadcast state also shows B as facilitator"
   );
 
-  // ── Step 3: B disconnects, facilitator falls back to A ──
-  log("Disconnecting B...");
+  // ── Step 3: B (creator) disconnects. Facilitator role is sticky to the creator. ──
+  // The facilitatorId should STAY pointing to B's (now-disconnected) participantId.
+  // It must NOT fall back to A. Reclaim-on-join will restore it when B reconnects.
+  log("Disconnecting B (creator)...");
+  const bParticipantId = b.id; // capture before close
   await close(b);
   await sleep(500); // let onClose propagate and broadcast
 
   assert(
-    a.getState().facilitatorId === a.id,
-    "After B disconnects, facilitator falls back to A"
+    a.getState().facilitatorId === bParticipantId,
+    "After B (creator) disconnects, facilitatorId stays as B's participantId (not reassigned to A)"
+  );
+  assert(
+    a.getState().facilitatorId !== a.id,
+    "facilitatorId is NOT A's id after B (creator) disconnects"
   );
 
-  // ── Step 4: B reconnects, reclaims facilitator ──
+  // ── Step 4: B reconnects. Reclaims facilitator via reclaim-on-join. ──
   log("Reconnecting B (creator)...");
   const b2 = await connect("Bob (Creator)", CREATOR_USER_ID);
   log(`  B2 joined, id=${b2.id}`);
 
+  // B2 gets a new participantId on reconnect. The reclaim-on-join logic in onConnect
+  // should promote B2 to facilitator because their userId matches state.createdBy.
   await waitForFacilitator(a.getState, b2.id);
 
   assert(
     b2.getState().facilitatorId === b2.id,
-    "B (creator) reclaims facilitator on reconnect"
+    "B (creator) reclaims facilitator on reconnect (no double-assignment)"
   );
   assert(
     a.getState().facilitatorId === b2.id,

--- a/tests/retro-group-labels.mjs
+++ b/tests/retro-group-labels.mjs
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for auto-generated group labels.
+ *
+ * Verifies that:
+ *   1. Cards with long text (>30 chars, >40 chars) produce group labels that
+ *      equal the full card text, not a truncated version.
+ *   2. The "advance to voting" auto-group path uses the full card text.
+ *   3. The proximity-grouping path uses the full card text.
+ *
+ * These tests operate against a running PartyKit server by sending events and
+ * asserting on the returned state — consistent with the project's test pattern.
+ *
+ * Usage: node tests/retro-group-labels.mjs [host] [roomId]
+ *
+ * Requires a running PartyKit dev server and the "ws" npm package.
+ */
+
+import WebSocket from "ws";
+
+const HOST = process.argv[2] || "127.0.0.1:1999";
+const ROOM_ID = process.argv[3] || `label-test-${Date.now().toString(36)}`;
+
+const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+function assert(condition, msg) {
+  if (condition) {
+    log(`PASS: ${msg}`);
+  } else {
+    log(`FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+function connect(name, userId = null) {
+  return new Promise((resolve, reject) => {
+    const qs = new URLSearchParams({ name });
+    if (userId) qs.set("userId", userId);
+    const url = `ws://${HOST}/parties/retro/${ROOM_ID}?${qs.toString()}`;
+    const ws = new WebSocket(url);
+    let resolved = false;
+    let latestState = null;
+
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) {
+          resolved = true;
+          resolve({ ws, id: data.you, anonymousId: data.anonymousId, getState: () => latestState });
+        }
+      } else if (data.type === "update") {
+        latestState = data.state;
+      }
+    });
+
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error(`Timeout for "${name}"`)); }, 5000);
+  });
+}
+
+function waitFor(getState, predicate, timeoutMs = 3000) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      const state = getState();
+      if (state && predicate(state)) return resolve(state);
+      if (Date.now() > deadline) return reject(new Error("waitFor timeout"));
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+async function run() {
+  log(`Room: ${ROOM_ID}`);
+
+  const fac = await connect("Facilitator");
+  log(`Facilitator joined, id=${fac.id}`);
+
+  // Start the retro (no previous actions, goes straight to writing)
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
+  log("Phase: writing");
+
+  // ── Scenario 1: auto-group label on advance-to-voting ──
+  // The old code truncated the label at 40 chars for this path.
+  const longText40 = "this is a fairly long topic name that exceeds forty characters easily yes it does";
+  assert(longText40.length > 40, "test text exceeds old 40-char threshold");
+
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText40 }));
+  await waitFor(fac.getState, (s) => s.cards.length > 0);
+
+  // Advance to grouping, then to voting (voting auto-groups ungrouped cards)
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
+  log("Phase: grouping");
+
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "voting");
+  log("Phase: voting");
+
+  const state = fac.getState();
+  assert(state.groups.length > 0, "at least one group exists after advance-to-voting");
+  const autoGroup = state.groups.find((g) => g.cardIds.length > 0);
+  assert(autoGroup !== undefined, "an auto-group was created");
+  assert(
+    autoGroup?.label === longText40,
+    `auto-group label equals full text (got "${autoGroup?.label?.slice(0, 50)}...")`
+  );
+
+  // ── Scenario 2: proximity-group label in grouping phase ──
+  // Use a separate room to test proximity grouping label via a fresh retro.
+  const ROOM_2 = `${ROOM_ID}-prox`;
+  const fac2 = await connect("Facilitator2");
+  // Connect to second room separately
+  const qs2 = new URLSearchParams({ name: "Fac2" });
+  const url2 = `ws://${HOST}/parties/retro/${ROOM_2}?${qs2.toString()}`;
+  const fac2b = await new Promise((resolve, reject) => {
+    const ws = new WebSocket(url2);
+    let latestState = null;
+    let resolved = false;
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) { resolved = true; resolve({ ws, id: data.you, getState: () => latestState }); }
+      } else if (data.type === "update") { latestState = data.state; }
+    });
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error("timeout")); }, 5000);
+  });
+
+  fac2b.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac2b.id }));
+  await waitFor(fac2b.getState, (s) => s.phase === "writing");
+
+  const longText30 = "this topic text is longer than thirty characters absolutely";
+  assert(longText30.length > 30, "test text exceeds old 30-char proximity threshold");
+
+  fac2b.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText30 }));
+  await waitFor(fac2b.getState, (s) => s.cards.length > 0);
+
+  // Advance to grouping
+  fac2b.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac2b.id }));
+  await waitFor(fac2b.getState, (s) => s.phase === "grouping");
+
+  // Move a card to trigger proximity grouping computation
+  const cardId = fac2b.getState().cards[0].id;
+  fac2b.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
+  await sleep(300);
+
+  const state2 = fac2b.getState();
+  const proxGroup = state2.groups.find((g) => g.cardIds.includes(cardId));
+  assert(proxGroup !== undefined, "proximity group contains the moved card");
+  assert(
+    proxGroup?.label === longText30,
+    `proximity group label equals full text (got "${proxGroup?.label?.slice(0, 50)}...")`
+  );
+
+  // ── Summary ──
+  log("=".repeat(50));
+  log("GROUP LABEL TESTS COMPLETE");
+  log("=".repeat(50));
+  if (failures === 0) {
+    log("ALL CHECKS PASSED");
+  } else {
+    log(`${failures} CHECK(S) FAILED`);
+  }
+
+  try { fac.ws.close(); } catch {}
+  try { fac2.ws.close(); } catch {}
+  try { fac2b.ws.close(); } catch {}
+
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+run().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});

--- a/tests/retro-group-labels.mjs
+++ b/tests/retro-group-labels.mjs
@@ -1,14 +1,11 @@
 /**
- * Unit tests for auto-generated group labels.
+ * Group label and chip-rename tests.
  *
- * Verifies that:
- *   1. Cards with long text (>30 chars, >40 chars) produce group labels that
- *      equal the full card text, not a truncated version.
- *   2. The "advance to voting" auto-group path uses the full card text.
- *   3. The proximity-grouping path uses the full card text.
- *
- * These tests operate against a running PartyKit server by sending events and
- * asserting on the returned state — consistent with the project's test pattern.
+ * Three scenarios:
+ *   1. Advance-to-voting auto-group label uses the full card text (was truncated at 40 chars).
+ *   2. Proximity-group label uses the full card text (was truncated at 30 chars).
+ *   3. Renaming a group via RENAME_GROUP (what the summary chip calls) persists the new label
+ *      in state, and survives a card move that re-triggers proximity computation.
  *
  * Usage: node tests/retro-group-labels.mjs [host] [roomId]
  *
@@ -18,7 +15,7 @@
 import WebSocket from "ws";
 
 const HOST = process.argv[2] || "127.0.0.1:1999";
-const ROOM_ID = process.argv[3] || `label-test-${Date.now().toString(36)}`;
+const BASE_ROOM = process.argv[3] || `labels-${Date.now().toString(36)}`;
 
 const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
@@ -33,11 +30,11 @@ function assert(condition, msg) {
   }
 }
 
-function connect(name, userId = null) {
+function connectRoom(name, roomId, userId = null) {
   return new Promise((resolve, reject) => {
     const qs = new URLSearchParams({ name });
     if (userId) qs.set("userId", userId);
-    const url = `ws://${HOST}/parties/retro/${ROOM_ID}?${qs.toString()}`;
+    const url = `ws://${HOST}/parties/retro/${roomId}?${qs.toString()}`;
     const ws = new WebSocket(url);
     let resolved = false;
     let latestState = null;
@@ -60,7 +57,7 @@ function connect(name, userId = null) {
   });
 }
 
-function waitFor(getState, predicate, timeoutMs = 3000) {
+function waitFor(getState, predicate, timeoutMs = 4000) {
   return new Promise((resolve, reject) => {
     const deadline = Date.now() + timeoutMs;
     const check = () => {
@@ -73,106 +70,140 @@ function waitFor(getState, predicate, timeoutMs = 3000) {
   });
 }
 
-async function run() {
-  log(`Room: ${ROOM_ID}`);
+// ── Scenario 1: advance-to-voting auto-group label ──
+async function testAutoGroupLabel() {
+  log("--- Scenario 1: auto-group full label on advance-to-voting ---");
+  const roomId = `${BASE_ROOM}-s1`;
+  const fac = await connectRoom("Fac1", roomId);
 
-  const fac = await connect("Facilitator");
-  log(`Facilitator joined, id=${fac.id}`);
-
-  // Start the retro (no previous actions, goes straight to writing)
   fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "writing");
-  log("Phase: writing");
 
-  // ── Scenario 1: auto-group label on advance-to-voting ──
-  // The old code truncated the label at 40 chars for this path.
-  const longText40 = "this is a fairly long topic name that exceeds forty characters easily yes it does";
-  assert(longText40.length > 40, "test text exceeds old 40-char threshold");
+  const longText = "this is a fairly long topic name that exceeds forty characters easily";
+  assert(longText.length > 40, "test text exceeds old 40-char auto-group threshold");
 
-  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText40 }));
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: longText }));
   await waitFor(fac.getState, (s) => s.cards.length > 0);
 
-  // Advance to grouping, then to voting (voting auto-groups ungrouped cards)
   fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "grouping");
-  log("Phase: grouping");
 
   fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
   await waitFor(fac.getState, (s) => s.phase === "voting");
-  log("Phase: voting");
 
   const state = fac.getState();
-  assert(state.groups.length > 0, "at least one group exists after advance-to-voting");
   const autoGroup = state.groups.find((g) => g.cardIds.length > 0);
-  assert(autoGroup !== undefined, "an auto-group was created");
+  assert(autoGroup !== undefined, "auto-group exists");
   assert(
-    autoGroup?.label === longText40,
-    `auto-group label equals full text (got "${autoGroup?.label?.slice(0, 50)}...")`
+    autoGroup?.label === longText,
+    `auto-group label is full text (got "${autoGroup?.label?.slice(0, 50)}")`
   );
 
-  // ── Scenario 2: proximity-group label in grouping phase ──
-  // Use a separate room to test proximity grouping label via a fresh retro.
-  const ROOM_2 = `${ROOM_ID}-prox`;
-  const fac2 = await connect("Facilitator2");
-  // Connect to second room separately
-  const qs2 = new URLSearchParams({ name: "Fac2" });
-  const url2 = `ws://${HOST}/parties/retro/${ROOM_2}?${qs2.toString()}`;
-  const fac2b = await new Promise((resolve, reject) => {
-    const ws = new WebSocket(url2);
-    let latestState = null;
-    let resolved = false;
-    ws.on("message", (raw) => {
-      const data = JSON.parse(raw.toString());
-      if (data.type === "sync") {
-        latestState = data.state;
-        if (!resolved) { resolved = true; resolve({ ws, id: data.you, getState: () => latestState }); }
-      } else if (data.type === "update") { latestState = data.state; }
-    });
-    ws.on("error", (err) => { if (!resolved) reject(err); });
-    setTimeout(() => { if (!resolved) reject(new Error("timeout")); }, 5000);
-  });
+  fac.ws.close();
+}
 
-  fac2b.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac2b.id }));
-  await waitFor(fac2b.getState, (s) => s.phase === "writing");
+// ── Scenario 2: proximity-group label ──
+async function testProximityGroupLabel() {
+  log("--- Scenario 2: proximity-group full label ---");
+  const roomId = `${BASE_ROOM}-s2`;
+  const fac = await connectRoom("Fac2", roomId);
 
-  const longText30 = "this topic text is longer than thirty characters absolutely";
-  assert(longText30.length > 30, "test text exceeds old 30-char proximity threshold");
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
 
-  fac2b.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText30 }));
-  await waitFor(fac2b.getState, (s) => s.cards.length > 0);
+  const longText = "this topic text is longer than thirty characters absolutely yes";
+  assert(longText.length > 30, "test text exceeds old 30-char proximity threshold");
 
-  // Advance to grouping
-  fac2b.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac2b.id }));
-  await waitFor(fac2b.getState, (s) => s.phase === "grouping");
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: longText }));
+  await waitFor(fac.getState, (s) => s.cards.length > 0);
 
-  // Move a card to trigger proximity grouping computation
-  const cardId = fac2b.getState().cards[0].id;
-  fac2b.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
-  await sleep(300);
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
 
-  const state2 = fac2b.getState();
-  const proxGroup = state2.groups.find((g) => g.cardIds.includes(cardId));
-  assert(proxGroup !== undefined, "proximity group contains the moved card");
+  const cardId = fac.getState().cards[0].id;
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId, x: 200, y: 200 }));
+  await sleep(400);
+
+  const state = fac.getState();
+  const proxGroup = state.groups.find((g) => g.cardIds.includes(cardId));
+  assert(proxGroup !== undefined, "proximity group contains the card");
   assert(
-    proxGroup?.label === longText30,
-    `proximity group label equals full text (got "${proxGroup?.label?.slice(0, 50)}...")`
+    proxGroup?.label === longText,
+    `proximity group label is full text (got "${proxGroup?.label?.slice(0, 50)}")`
   );
 
-  // ── Summary ──
+  fac.ws.close();
+}
+
+// ── Scenario 3: chip rename persists through card moves ──
+async function testChipRenamePersistedThroughMove() {
+  log("--- Scenario 3: group rename via chip persists after card move ---");
+  const roomId = `${BASE_ROOM}-s3`;
+  const fac = await connectRoom("Fac3", roomId);
+
+  fac.ws.send(JSON.stringify({ type: "START_RETRO", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "writing");
+
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "happy", text: "card alpha" }));
+  fac.ws.send(JSON.stringify({ type: "ADD_CARD", category: "sad", text: "card beta" }));
+  await waitFor(fac.getState, (s) => s.cards.length >= 2);
+
+  fac.ws.send(JSON.stringify({ type: "ADVANCE_PHASE", facilitatorId: fac.id }));
+  await waitFor(fac.getState, (s) => s.phase === "grouping");
+
+  // Move two cards close together to form a proximity group
+  const cards = fac.getState().cards;
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[0].id, x: 100, y: 100 }));
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[1].id, x: 140, y: 120 }));
+  await sleep(400);
+
+  const groupsBefore = fac.getState().groups;
+  assert(groupsBefore.length > 0, "groups formed by proximity");
+
+  const groupId = groupsBefore[0].id;
+  const newLabel = "Our renamed group via chip";
+
+  // Send the same RENAME_GROUP event the chip calls through onRenameGroup
+  fac.ws.send(JSON.stringify({ type: "RENAME_GROUP", groupId, label: newLabel }));
+  await waitFor(fac.getState, (s) => s.groups.some((g) => g.id === groupId && g.label === newLabel));
+
+  assert(
+    fac.getState().groups.find((g) => g.id === groupId)?.label === newLabel,
+    "label updated to chip-renamed value"
+  );
+
+  // Move a card slightly: proximity recomputes, but renamedLabels fingerprint should restore the label
+  fac.ws.send(JSON.stringify({ type: "MOVE_CARD_POSITION", cardId: cards[0].id, x: 110, y: 105 }));
+  await sleep(400);
+
+  const labelAfterMove = fac.getState().groups.find((g) =>
+    g.cardIds.includes(cards[0].id) || g.cardIds.includes(cards[1].id)
+  )?.label;
+  assert(
+    labelAfterMove === newLabel,
+    `label persists after card move (got "${labelAfterMove}")`
+  );
+
+  fac.ws.close();
+}
+
+async function run() {
+  log(`Base room: ${BASE_ROOM}`);
+
+  await testAutoGroupLabel();
+  await testProximityGroupLabel();
+  await testChipRenamePersistedThroughMove();
+
   log("=".repeat(50));
-  log("GROUP LABEL TESTS COMPLETE");
+  log("GROUP LABEL + CHIP RENAME TESTS COMPLETE");
   log("=".repeat(50));
   if (failures === 0) {
     log("ALL CHECKS PASSED");
+    process.exit(0);
   } else {
     log(`${failures} CHECK(S) FAILED`);
+    process.exit(1);
   }
-
-  try { fac.ws.close(); } catch {}
-  try { fac2.ws.close(); } catch {}
-  try { fac2b.ws.close(); } catch {}
-
-  process.exit(failures === 0 ? 0 : 1);
 }
 
 run().catch((err) => {

--- a/tests/retro-typing-indicator.mjs
+++ b/tests/retro-typing-indicator.mjs
@@ -1,0 +1,161 @@
+/**
+ * Anonymous typing indicator tests.
+ *
+ * Two scenarios:
+ *   1. Participant A starts typing. Participant B receives a typing_update with
+ *      participantIds containing A's id. A stops typing. B's indicator clears.
+ *      Names must never appear in any typing_update broadcast.
+ *   2. A disconnects mid-typing. B's typing indicator clears within one tick.
+ *
+ * Usage: node tests/retro-typing-indicator.mjs [host] [roomId]
+ *
+ * Requires a running PartyKit dev server and the "ws" npm package.
+ */
+
+import WebSocket from "ws";
+
+const HOST = process.argv[2] || "127.0.0.1:1999";
+const BASE_ROOM = process.argv[3] || `typing-${Date.now().toString(36)}`;
+
+const log = (msg) => console.log(`[${new Date().toISOString().slice(11, 19)}] ${msg}`);
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+let failures = 0;
+function assert(condition, msg) {
+  if (condition) {
+    log(`PASS: ${msg}`);
+  } else {
+    log(`FAIL: ${msg}`);
+    failures++;
+  }
+}
+
+function connectRoom(name, roomId) {
+  return new Promise((resolve, reject) => {
+    const qs = new URLSearchParams({ name });
+    const url = `ws://${HOST}/parties/retro/${roomId}?${qs.toString()}`;
+    const ws = new WebSocket(url);
+    let resolved = false;
+    let latestState = null;
+    let latestTypingIds = [];
+    const typingUpdates = [];
+
+    ws.on("message", (raw) => {
+      const data = JSON.parse(raw.toString());
+      if (data.type === "sync") {
+        latestState = data.state;
+        if (!resolved) {
+          resolved = true;
+          resolve({
+            ws,
+            id: data.you,
+            name,
+            getState: () => latestState,
+            getTypingIds: () => latestTypingIds,
+            getTypingUpdates: () => typingUpdates,
+          });
+        }
+      } else if (data.type === "update") {
+        latestState = data.state;
+      } else if (data.type === "typing_update") {
+        latestTypingIds = data.participantIds;
+        typingUpdates.push({ participantIds: [...data.participantIds], ts: Date.now() });
+      }
+    });
+
+    ws.on("error", (err) => { if (!resolved) reject(err); });
+    setTimeout(() => { if (!resolved) reject(new Error(`Timeout for "${name}"`)); }, 5000);
+  });
+}
+
+function waitFor(getVal, predicate, timeoutMs = 4000) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+    const check = () => {
+      const val = getVal();
+      if (predicate(val)) return resolve(val);
+      if (Date.now() > deadline) return reject(new Error("waitFor timeout"));
+      setTimeout(check, 100);
+    };
+    check();
+  });
+}
+
+// ── Scenario 1: A types, B sees indicator; A stops, indicator clears; no names in broadcast ──
+async function testTypingIndicatorBasic() {
+  log("--- Scenario 1: typing indicator appears and clears ---");
+  const roomId = `${BASE_ROOM}-s1`;
+  const a = await connectRoom("Alice", roomId);
+  const b = await connectRoom("Bob", roomId);
+  log(`A=${a.id} B=${b.id}`);
+
+  // Send TYPING_START from A
+  a.ws.send(JSON.stringify({ type: "TYPING_START" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length > 0);
+
+  const idsAfterStart = b.getTypingIds();
+  assert(idsAfterStart.includes(a.id), "B sees A's participantId in typing_update");
+  assert(!idsAfterStart.includes("Alice"), "B does not see A's name in typing_update");
+
+  // Verify no name appears in any typing_update B has received
+  const allUpdates = b.getTypingUpdates();
+  const nameLeaked = allUpdates.some((u) =>
+    u.participantIds.some((id) => id === "Alice" || id === "Bob")
+  );
+  assert(!nameLeaked, "No name (Alice/Bob) appeared in any typing_update broadcast");
+
+  // Send TYPING_STOP from A
+  a.ws.send(JSON.stringify({ type: "TYPING_STOP" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length === 0);
+
+  assert(b.getTypingIds().length === 0, "indicator clears after TYPING_STOP");
+
+  a.ws.close();
+  b.ws.close();
+}
+
+// ── Scenario 2: A disconnects mid-typing; B's indicator clears ──
+async function testTypingClearsOnDisconnect() {
+  log("--- Scenario 2: indicator clears when typer disconnects ---");
+  const roomId = `${BASE_ROOM}-s2`;
+  const a = await connectRoom("Alice2", roomId);
+  const b = await connectRoom("Bob2", roomId);
+
+  // A starts typing but does not stop
+  a.ws.send(JSON.stringify({ type: "TYPING_START" }));
+  await waitFor(b.getTypingIds, (ids) => ids.length > 0);
+  assert(b.getTypingIds().includes(a.id), "B sees A typing before disconnect");
+
+  // A disconnects without sending TYPING_STOP
+  a.ws.close();
+
+  // B's indicator should clear when the server processes onClose
+  await waitFor(b.getTypingIds, (ids) => ids.length === 0, 5000);
+  assert(b.getTypingIds().length === 0, "indicator clears after A disconnects mid-typing");
+
+  b.ws.close();
+}
+
+async function run() {
+  log(`Base room: ${BASE_ROOM}`);
+
+  await testTypingIndicatorBasic();
+  await sleep(200);
+  await testTypingClearsOnDisconnect();
+
+  log("=".repeat(50));
+  log("TYPING INDICATOR TESTS COMPLETE");
+  log("=".repeat(50));
+  if (failures === 0) {
+    log("ALL CHECKS PASSED");
+    process.exit(0);
+  } else {
+    log(`${failures} CHECK(S) FAILED`);
+    process.exit(1);
+  }
+}
+
+run().catch((err) => {
+  console.error("FATAL:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Context

Two bugs found during 2026-04-30 dogfood session.

## Fixes

- **Pricing route** (`src/app/(marketing)/pricing/page.tsx`, new file): `/pricing` was returning the app 404 page. Added a server-side redirect to `/#pricing` so the landing page pricing anchor is reached from direct links and SEO-indexed URLs.

- **Closed retro summary** (`src/app/(app)/retro/[id]/page.tsx` + `src/app/(app)/retro/[id]/retro-room-client.tsx` + `src/components/retro/closed-retro-summary.tsx`): retros with `status='closed'` in the DB were rendering the join lobby to anyone with the URL. The page is now a server component that queries the DB by `roomCode` first. If `status='closed'`, it renders a read-only `ClosedRetroSummary` (groups ranked by votes, cards by category, action items per group plus a general section, no interactive controls, no PartyKit connection). If the query fails or returns an active retro, it falls through to the existing `RetroRoomClient` unchanged.

## Tests

17 unit tests in `tests/retro-closed-summary.mjs` validate the data-shape transform (group construction, card assignment, action item routing, rank sorting, null assignees fallback). Integration test path is also in the file and runs when `DATABASE_URL` and `APP_HOST` are set.

## Stack

This stacks on PR #12 which stacks on PR #11. Merge order: #11 then #12 then this PR.

---